### PR TITLE
fix https://github.com/nitely/nim-regex/issues/24

### DIFF
--- a/regex.nimble
+++ b/regex.nimble
@@ -1,13 +1,13 @@
 # Package
 
-version = "0.8.0"
+version = "0.9.0"
 author = "Esteban Castro Borsani (@nitely)"
 description = "Linear time regex matching"
 license = "MIT"
 srcDir = "src"
 skipDirs = @["tests"]
 
-requires "nim >= 0.18.0"
+requires "nim >= 0.19.0"
 requires "unicodedb >= 0.6.0 & < 0.7"
 requires "unicodeplus >= 0.4.0 & < 0.5"
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2850,15 +2850,15 @@ proc toPattern*(s: string): Regex {.raises: [RegexError].} =
     namedGroups: names)
 
 when defined(forceRegexAtRuntime):
-  proc re*(s: string): Regex =
+  proc re*(s: string): Regex {.inline.} =
     toPattern(s)
 else:
-  proc re*(s: static string): Regex =
+  proc re*(s: static string): Regex {.inline.} =
     ## Parse and compile a regular expression at compile-time
     const pattern = toPattern(s)
     pattern
 
-  proc re*(s: string): Regex =
+  proc re*(s: string): Regex {.inline.} =
     ## Parse and compile a regular expression at run-time
     toPattern(s)
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2831,6 +2831,7 @@ proc replace*(
 
 proc toPattern*(s: string): Regex {.raises: [RegexError].} =
   ## Parse and compile a regular expression.
+  ## Deprecated: use directly `re` instead which works both at RT and CT.
   ##
   ## .. code-block:: nim
   ##   # compiled at run-time
@@ -2852,11 +2853,14 @@ when defined(forceRegexAtRuntime):
   template re*(s: string): Regex =
     toPattern(s)
 else:
-  template re*(s: string): Regex =
-    ## Parse and compile a regular
-    ## expression at compile-time
+  template re*(s: static string): Regex =
+    ## Parse and compile a regular expression at compile-time
     const pattern = toPattern(s)
     pattern
+
+  template re*(s: string): Regex =
+    ## Parse and compile a regular expression at run-time
+    toPattern(s)
 
 when isMainModule:
   proc toAtoms(s: string): string =
@@ -2920,3 +2924,10 @@ when isMainModule:
   doAssert(r"[[:word:]]".toAtoms == "[[_0-9a-zA-Z]]")
   doAssert(r"[[:xdigit:]]".toAtoms == "[[0-9a-fA-F]]")
   doAssert(r"[[:alpha:][:digit:]]".toAtoms == "[[a-zA-Z][0-9]]")
+
+  # https://github.com/nitely/nim-regex/issues/24
+  block:
+    const a1 = re"foo"
+    const a2 = re("foo")
+    let pattern = "foo"
+    let a3 = re(pattern)

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2850,15 +2850,15 @@ proc toPattern*(s: string): Regex {.raises: [RegexError].} =
     namedGroups: names)
 
 when defined(forceRegexAtRuntime):
-  template re*(s: string): Regex =
+  proc re*(s: string): Regex =
     toPattern(s)
 else:
-  template re*(s: static string): Regex =
+  proc re*(s: static string): Regex =
     ## Parse and compile a regular expression at compile-time
     const pattern = toPattern(s)
     pattern
 
-  template re*(s: string): Regex =
+  proc re*(s: string): Regex =
     ## Parse and compile a regular expression at run-time
     toPattern(s)
 


### PR DESCRIPTION
we can add `{.deprecated .}` to `toPattern` in subsequent PR