### PR TITLE
Fix all styleCheck warnings and enforce styleCheck

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,5 @@
+const
+  nimVersion = (major: NimMajor, minor: NimMinor, patch: NimPatch)
+
+when nimVersion > (0, 20, 2):
+  switch("styleCheck", "error")

--- a/regex.nimble
+++ b/regex.nimble
@@ -4,7 +4,7 @@ version = "0.11.2"
 author = "Esteban Castro Borsani (@nitely)"
 description = "Linear time regex matching"
 license = "MIT"
-srcDir = "src"
+srcdir = "src"
 skipDirs = @["tests"]
 
 requires "nim >= 0.18.0"


### PR DESCRIPTION
The warnings were found by running with --styleCheck:hint.

Fixes:

- s/prettycheck/prettyCheck/
- s/rawCp/rawCP/

- s/reSet/reInSet/ <-- This one in particular is a workaround for Nim
                       issue https://github.com/nim-lang/Nim/issues/11756

Note that the styleCheck enforcing will work only with Nim 0.20.0 and
newer because the --styleCheck switch got introduced in that version.

The --styleCheck:error will result in errors on nim 0.20.0 and 0.20.2
due to styleCheck failures on few stdlibs. Those will be fixed on Nim
devel soon. So I am enabling the --styleCheck:error switch only on
nim versions newer than 0.20.2.
