### PR TITLE
Capturing groups improvements

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -337,7 +337,7 @@ template initSetNodeImpl(result: var Node, k: NodeKind) =
   result = Node(
     kind: k,
     cp: "¿".toRune,
-    cps: initHashSet[Rune](),
+    cps: initSet[Rune](),
     ranges: @[],
     shorthands: @[])
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2102,7 +2102,7 @@ proc groupsCount*(m: RegexMatch): int =
   m.groups.len
 
 
-proc groupsNames*(m: RegexMatch): seq[string] =
+proc groupNames*(m: RegexMatch): seq[string] =
   ## return the names of capturing groups
   ##
   ## .. code-block:: nim
@@ -2110,13 +2110,16 @@ proc groupsNames*(m: RegexMatch): seq[string] =
   ##     var m: RegexMatch
   ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
   ##     doAssert m.groupsCount == 2
+  ##     let groupNames = m.groupNames
+  ##     for name in @["who", "greet"]:
+  ##       doAssert groupNames.contains(name)
+
+  result = newSeq[string]()
+  result = toSeq(m.namedGroups.keys)
 
 
-  toSeq(m.namedGroups.keys)
-
-
-proc groupsByName*(m: RegexMatch, name: string, originalText: string): seq[string] =
-  ## return capturing groups by name
+proc groups*(m: RegexMatch, groupName: string, originalText: string): seq[string] =
+  ## Return all captures for a given capturing group
   ##
   ## .. code-block:: nim
   ##   block:
@@ -2124,26 +2127,40 @@ proc groupsByName*(m: RegexMatch, name: string, originalText: string): seq[strin
   ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
   ##     doAssert m.groupByName("greet") == @["hello"]
   ##     doAssert m.groupByName("who") == @["world"]
-  
-  for bounds in m.group(name):
+  result = newSeq[string]()
+  for bounds in m.group(groupName):
     result.add(originalText[bounds])
 
 
-proc groupByName*(m: RegexMatch, name: string, originalText: string): string =
-  ## return capturing groups by name
+proc groupFirstCapture*(m: RegexMatch, groupName: string, originalText: string): string =
+  ##  Return first capture for a given capturing group
   ##
   ## .. code-block:: nim
   ##   block:
   ##     var m: RegexMatch
-  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert "hello world her".match("(?P<greet>hello) (?P<who>world) (?P<who>her", m)
   ##     doAssert m.groupByName("greet") == "hello"
   ##     doAssert m.groupByName("who") == "world"
   
-  for bounds in m.group(name):
-    result.add(originalText[bounds])
-    # first one only.
+  for bounds in m.group(groupName):
+    result = originalText[bounds]
+    echo "result firstCapture: " & groupName & " in text : " & originalText & result
     return
 
+proc groupLastCapture*(m: RegexMatch, groupName: string, originalText: string): string =
+  ##  Return first capture for a given capturing group
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     var m: RegexMatch
+  ##     doAssert "hello world her".match("(?P<greet>hello) (?P<who>world) (?P<who>her", m)
+  ##     doAssert m.groupByName("greet") == "hello"
+  ##     doAssert m.groupByName("who") == "her"
+  
+  let boundsSeq = m.group(groupName).toSeq
+  echo "BOUNDS SEQ: " & $boundsSeq
+  result = originalText[boundsSeq[boundsSeq.len-1]]
+  echo "result lastCapture: " & groupName & " in text : " & originalText & result
 
 
 proc stringify(pattern: Regex, nIdx: int16, visited: var set[int16]): string =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -154,6 +154,7 @@ import strutils
 import sets
 import tables
 import parseutils
+import sequtils
 
 import unicodedb/properties
 import unicodedb/types
@@ -336,7 +337,7 @@ template initSetNodeImpl(result: var Node, k: NodeKind) =
   result = Node(
     kind: k,
     cp: "¿".toRune,
-    cps: initSet[Rune](),
+    cps: initHashSet[Rune](),
     ranges: @[],
     shorthands: @[])
 
@@ -2099,6 +2100,51 @@ proc groupsCount*(m: RegexMatch): int =
   ##     doAssert m.groupsCount == 2
   ##
   m.groups.len
+
+
+proc groupsNames*(m: RegexMatch): seq[string] =
+  ## return the names of capturing groups
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     var m: RegexMatch
+  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert m.groupsCount == 2
+
+
+  toSeq(m.namedGroups.keys)
+
+
+proc groupsByName*(m: RegexMatch, name: string, originalText: string): seq[string] =
+  ## return capturing groups by name
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     var m: RegexMatch
+  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert m.groupByName("greet") == @["hello"]
+  ##     doAssert m.groupByName("who") == @["world"]
+  
+  for bounds in m.group(name):
+    result.add(originalText[bounds])
+
+
+proc groupByName*(m: RegexMatch, name: string, originalText: string): string =
+  ## return capturing groups by name
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     var m: RegexMatch
+  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert m.groupByName("greet") == "hello"
+  ##     doAssert m.groupByName("who") == "world"
+  
+  for bounds in m.group(name):
+    result.add(originalText[bounds])
+    # first one only.
+    return
+
+
 
 proc stringify(pattern: Regex, nIdx: int16, visited: var set[int16]): string =
   ## NFA to string representation.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2137,7 +2137,7 @@ proc group*(m: RegexMatch, groupName: string, text:string): seq[string] =
     result.add text[bounds]
 
 proc groupFirstCapture*(m: RegexMatch, groupName: string, text: string): string =
-  ##  Return last capture for a given capturing group
+  ##  Return fist capture for a given capturing group
   ##
   ## .. code-block:: nim
   ##   block:
@@ -2151,8 +2151,18 @@ proc groupFirstCapture*(m: RegexMatch, groupName: string, text: string): string 
   ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
   ##     # "who" captures @["world", "foo", "bar"]
   ##     doAssert m.groupFirstCapture("who", text) == "world"
-  
-  m.group(groupName, text)[0]
+  ##   block:
+  ##     let text = "hello"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello)\s?(?P<who>world)?", m)
+  ##     doAssert m.groupFirstCapture("greet", text) == "hello"
+  ##     doAssert m.groupFirstCapture("who", text) == ""
+
+  let captures = m.group(groupName, text)
+  if captures.len > 0:
+    return captures[0]
+  else:
+    return "" 
 
 proc groupLastCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##  Return last capture for a given capturing group
@@ -2169,9 +2179,18 @@ proc groupLastCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
   ##     # "who" captures @["world", "foo", "bar"]
   ##     doAssert m.groupLastCapture("who", text) == "bar"
+  ##   block:
+  ##     let text = "hello"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello)\s?(?P<who>world)?", m)
+  ##     doAssert m.groupLastCapture("greet", text) == "hello"
+  ##     doAssert m.groupLastCapture("who", text) == ""
 
-  let groups = m.group(groupName, text)
-  result = groups[groups.len-1]
+  let captures = m.group(groupName, text)
+  if captures.len > 0:
+    return captures[captures.len-1]
+  else:
+    return "" 
 
 
 proc stringify(pattern: Regex, nIdx: int16, visited: var set[int16]): string =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2107,61 +2107,38 @@ proc groupNames*(m: RegexMatch): seq[string] =
   ##
   ## .. code-block:: nim
   ##   block:
+  ##     let text = "hello world"
   ##     var m: RegexMatch
-  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
-  ##     doAssert m.groupsCount == 2
-  ##     let groupNames = m.groupNames
-  ##     for name in @["who", "greet"]:
-  ##       doAssert groupNames.contains(name)
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert m.groupCapture("greet", text) == "hello"
+  ##     doAssert m.groupCapture("who", text) == "world"
 
   result = newSeq[string]()
   result = toSeq(m.namedGroups.keys)
 
 
-proc groups*(m: RegexMatch, groupName: string, originalText: string): seq[string] =
-  ## Return all captures for a given capturing group
+proc groupCapture*(m: RegexMatch, groupName: string, text: string): string =
+  ##  Return last capture for a given capturing group
   ##
   ## .. code-block:: nim
   ##   block:
+  ##  
+  ##     let text = "hello world her"
   ##     var m: RegexMatch
-  ##     doAssert "hello world".match("(?P<greet>hello) (?P<who>world)", m)
-  ##     doAssert m.groupByName("greet") == @["hello"]
-  ##     doAssert m.groupByName("who") == @["world"]
-  result = newSeq[string]()
-  for bounds in m.group(groupName):
-    result.add(originalText[bounds])
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+  ##     doAssert m.groupsCount == 3
+  ##  
+  ##     for group in @["greet", "who"]:
+  ##       doAssert m.groupNames.contains(group)
+  ##  
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+  ##     doAssert m.groupCapture("greet", text) == "hello"
+  ##     doAssert m.groupCapture("who", text) == "her"
 
-
-proc groupFirstCapture*(m: RegexMatch, groupName: string, originalText: string): string =
-  ##  Return first capture for a given capturing group
-  ##
-  ## .. code-block:: nim
-  ##   block:
-  ##     var m: RegexMatch
-  ##     doAssert "hello world her".match("(?P<greet>hello) (?P<who>world) (?P<who>her", m)
-  ##     doAssert m.groupByName("greet") == "hello"
-  ##     doAssert m.groupByName("who") == "world"
   
   for bounds in m.group(groupName):
-    result = originalText[bounds]
-    echo "result firstCapture: " & groupName & " in text : " & originalText & result
+    result = text[bounds]
     return
-
-proc groupLastCapture*(m: RegexMatch, groupName: string, originalText: string): string =
-  ##  Return first capture for a given capturing group
-  ##
-  ## .. code-block:: nim
-  ##   block:
-  ##     var m: RegexMatch
-  ##     doAssert "hello world her".match("(?P<greet>hello) (?P<who>world) (?P<who>her", m)
-  ##     doAssert m.groupByName("greet") == "hello"
-  ##     doAssert m.groupByName("who") == "her"
-  
-  let boundsSeq = m.group(groupName).toSeq
-  echo "BOUNDS SEQ: " & $boundsSeq
-  result = originalText[boundsSeq[boundsSeq.len-1]]
-  echo "result lastCapture: " & groupName & " in text : " & originalText & result
-
 
 proc stringify(pattern: Regex, nIdx: int16, visited: var set[int16]): string =
   ## NFA to string representation.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2107,13 +2107,11 @@ proc groupNames*(m: RegexMatch): seq[string] =
   ##
   ## .. code-block:: nim
   ##   block:
-  ##     let text = "hello world"
+  ##     let text = "hello world her"
   ##     var m: RegexMatch
-  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
-  ##     doAssert m.groupCapture("greet", text) == "hello"
-  ##     doAssert m.groupCapture("who", text) == "world"
-
-  result = newSeq[string]()
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+  ##     for group in @["greet", "who"]:
+  ##       doAssert m.groupNames.contains(group)
   result = toSeq(m.namedGroups.keys)
 
 
@@ -2122,15 +2120,8 @@ proc groupCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##
   ## .. code-block:: nim
   ##   block:
-  ##  
   ##     let text = "hello world her"
   ##     var m: RegexMatch
-  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
-  ##     doAssert m.groupsCount == 3
-  ##  
-  ##     for group in @["greet", "who"]:
-  ##       doAssert m.groupNames.contains(group)
-  ##  
   ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
   ##     doAssert m.groupCapture("greet", text) == "hello"
   ##     doAssert m.groupCapture("who", text) == "her"

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2125,7 +2125,12 @@ proc groupCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
   ##     doAssert m.groupCapture("greet", text) == "hello"
   ##     doAssert m.groupCapture("who", text) == "her"
-
+  ##   block:
+  ##     let text = "hello world foo bar"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+  ##     # "who" captures @["world", "foo", "bar"]
+  ##     doAssert m.groupCapture("who", text) == "world"
   
   for bounds in m.group(groupName):
     result = text[bounds]

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -2114,8 +2114,29 @@ proc groupNames*(m: RegexMatch): seq[string] =
   ##       doAssert m.groupNames.contains(group)
   result = toSeq(m.namedGroups.keys)
 
+proc group*(m: RegexMatch, groupName: string, text:string): seq[string] = 
+  ## return seq of captured text by group `groupName`
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     let text = "hello world"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+  ##     doAssert m.group("greet", text) == @["hello"]
+  ##     doAssert m.group("who", text) == @["world"]
+  ##   block:
+  ##     let text = "hello world foo bar"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+  ##     doAssert m.group("greet", text) == @["hello"]
+  ##     let whoGroups = m.group("who", text)
+  ##     for w in @["foo", "bar", "world"]:
+  ##       doAssert whoGroups.contains(w)
+  result = newSeq[string]()
+  for bounds in m.group(groupName):
+    result.add text[bounds]
 
-proc groupCapture*(m: RegexMatch, groupName: string, text: string): string =
+proc groupFirstCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##  Return last capture for a given capturing group
   ##
   ## .. code-block:: nim
@@ -2123,18 +2144,35 @@ proc groupCapture*(m: RegexMatch, groupName: string, text: string): string =
   ##     let text = "hello world her"
   ##     var m: RegexMatch
   ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
-  ##     doAssert m.groupCapture("greet", text) == "hello"
-  ##     doAssert m.groupCapture("who", text) == "her"
+  ##     doAssert m.groupFirstCapture("greet", text) == "hello"
   ##   block:
   ##     let text = "hello world foo bar"
   ##     var m: RegexMatch
   ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
   ##     # "who" captures @["world", "foo", "bar"]
-  ##     doAssert m.groupCapture("who", text) == "world"
+  ##     doAssert m.groupFirstCapture("who", text) == "world"
   
-  for bounds in m.group(groupName):
-    result = text[bounds]
-    return
+  m.group(groupName, text)[0]
+
+proc groupLastCapture*(m: RegexMatch, groupName: string, text: string): string =
+  ##  Return last capture for a given capturing group
+  ##
+  ## .. code-block:: nim
+  ##   block:
+  ##     let text = "hello world her"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+  ##     doAssert m.groupLastCapture("who", text) == "her"
+  ##   block:
+  ##     let text = "hello world foo bar"
+  ##     var m: RegexMatch
+  ##     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+  ##     # "who" captures @["world", "foo", "bar"]
+  ##     doAssert m.groupLastCapture("who", text) == "bar"
+
+  let groups = m.group(groupName, text)
+  result = groups[groups.len-1]
+
 
 proc stringify(pattern: Regex, nIdx: int16, visited: var set[int16]): string =
   ## NFA to string representation.

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1415,3 +1415,21 @@ test "tisInitialized":
     assert(not re.isInitialized)
     re = re"foo"
     assert re.isInitialized
+
+test "capturingGroupsNames":
+  block:
+    let text = "hello world"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+    doAssert m.groupsCount == 2
+    for name in @["greet", "who"]:
+      doAssert m.groupsNames.contains(name)
+
+  block:
+    let text = "hello world"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+    doAssert m.groupsByName("greet", text) == @["hello"]
+    doAssert m.groupsByName("who", text) == @["world"]
+    doAssert m.groupByName("greet", text) == "hello"
+    doAssert m.groupByName("who", text) == "world"

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1440,4 +1440,10 @@ test "capturingGroupsNames":
     doAssert m.groupCapture("greet", text) == "hello"
     doAssert m.groupCapture("who", text) == "her"
 
+  block:
+    let text = "hello world foo bar"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+    # "who" captures @["world", "foo", "bar"]
+    doAssert m.groupCapture("who", text) == "world"
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1429,20 +1429,8 @@ test "capturingGroupsNames":
     let text = "hello world"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
-    doAssert m.groups("greet", text) == @["hello"]
-    doAssert m.groups("who", text) == @["world"]
-    doAssert m.groupFirstCapture("greet", text) == "hello"
-    doAssert m.groupFirstCapture("who", text) == "world"
-
-  block:
-    let text = "hello world"
-    var m: RegexMatch
-    doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
-    doAssert m.groups("greet", text) == @["hello"]
-    doAssert m.groups("who", text) == @["world"]
-    doAssert m.groupLastCapture("greet", text) == "hello"
-    doAssert m.groupLastCapture("who", text) == "world"
-
+    doAssert m.groupCapture("greet", text) == "hello"
+    doAssert m.groupCapture("who", text) == "world"
 
   block:
 
@@ -1450,16 +1438,12 @@ test "capturingGroupsNames":
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
     doAssert m.groupsCount == 3
-    doAssert m.groups("greet", text) == @["hello"]
 
     for group in @["greet", "who"]:
       doAssert m.groupNames.contains(group)
 
     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
-    doAssert m.groupFirstCapture("greet", text) == "hello"
-    doAssert m.groupFirstCapture("who", text) == "world"
-
-    doAssert m.groupLastCapture("greet", text) == "hello"
-    doAssert m.groupLastCapture("who", text) == "her"
+    doAssert m.groupCapture("greet", text) == "hello"
+    doAssert m.groupCapture("who", text) == "her"
 
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1423,13 +1423,43 @@ test "capturingGroupsNames":
     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
     doAssert m.groupsCount == 2
     for name in @["greet", "who"]:
-      doAssert m.groupsNames.contains(name)
+      doAssert m.groupNames.contains(name)
 
   block:
     let text = "hello world"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
-    doAssert m.groupsByName("greet", text) == @["hello"]
-    doAssert m.groupsByName("who", text) == @["world"]
-    doAssert m.groupByName("greet", text) == "hello"
-    doAssert m.groupByName("who", text) == "world"
+    doAssert m.groups("greet", text) == @["hello"]
+    doAssert m.groups("who", text) == @["world"]
+    doAssert m.groupFirstCapture("greet", text) == "hello"
+    doAssert m.groupFirstCapture("who", text) == "world"
+
+  block:
+    let text = "hello world"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+    doAssert m.groups("greet", text) == @["hello"]
+    doAssert m.groups("who", text) == @["world"]
+    doAssert m.groupLastCapture("greet", text) == "hello"
+    doAssert m.groupLastCapture("who", text) == "world"
+
+
+  block:
+
+    let text = "hello world her"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+    doAssert m.groupsCount == 3
+    doAssert m.groups("greet", text) == @["hello"]
+
+    for group in @["greet", "who"]:
+      doAssert m.groupNames.contains(group)
+
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+    doAssert m.groupFirstCapture("greet", text) == "hello"
+    doAssert m.groupFirstCapture("who", text) == "world"
+
+    doAssert m.groupLastCapture("greet", text) == "hello"
+    doAssert m.groupLastCapture("who", text) == "her"
+
+

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1462,6 +1462,13 @@ test "capturingGroupsNames":
     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
     # "who" captures @["world", "foo", "bar"]
     doAssert m.groupFirstCapture("who", text) == "world"
+  
+  block:
+    let text = "hello"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello)\s?(?P<who>world)?", m)
+    doAssert m.groupFirstCapture("greet", text) == "hello"
+    doAssert m.groupFirstCapture("who", text) == ""
 
   ## Last capture
   block:
@@ -1476,3 +1483,10 @@ test "capturingGroupsNames":
     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
     # "who" captures @["world", "foo", "bar"]
     doAssert m.groupLastCapture("who", text) == "bar"
+
+  block:
+    let text = "hello"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello)\s?(?P<who>world)?", m)
+    doAssert m.groupLastCapture("greet", text) == "hello"
+    doAssert m.groupLastCapture("who", text) == ""

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1429,21 +1429,50 @@ test "capturingGroupsNames":
     let text = "hello world"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
-    doAssert m.groupCapture("greet", text) == "hello"
-    doAssert m.groupCapture("who", text) == "world"
+    doAssert m.group("greet", text) == @["hello"]
+    doAssert m.group("who", text) == @["world"]
+    
+  block:
+    let text = "hello world foo bar"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+    doAssert m.group("greet", text) == @["hello"]
+    let whoGroups = m.group("who", text)
+    for w in @["foo", "bar", "world"]:
+      doAssert whoGroups.contains(w)
+
 
   block:
+    let text = "hello world"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world)", m)
+    doAssert m.groupFirstCapture("greet", text) == "hello"
+    doAssert m.groupFirstCapture("who", text) == "world"
 
+  ## First capture
+  block:
     let text = "hello world her"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
-    doAssert m.groupCapture("greet", text) == "hello"
-    doAssert m.groupCapture("who", text) == "her"
+    doAssert m.groupFirstCapture("greet", text) == "hello"
 
   block:
     let text = "hello world foo bar"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
     # "who" captures @["world", "foo", "bar"]
-    doAssert m.groupCapture("who", text) == "world"
+    doAssert m.groupFirstCapture("who", text) == "world"
 
+  ## Last capture
+  block:
+    let text = "hello world her"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
+    doAssert m.groupLastCapture("who", text) == "her"
+
+  block:
+    let text = "hello world foo bar"
+    var m: RegexMatch
+    doAssert text.match(re"(?P<greet>hello) (?:(?P<who>[^\s]+)\s?)+", m)
+    # "who" captures @["world", "foo", "bar"]
+    doAssert m.groupLastCapture("who", text) == "bar"

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1437,12 +1437,6 @@ test "capturingGroupsNames":
     let text = "hello world her"
     var m: RegexMatch
     doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
-    doAssert m.groupsCount == 3
-
-    for group in @["greet", "who"]:
-      doAssert m.groupNames.contains(group)
-
-    doAssert text.match(re"(?P<greet>hello) (?P<who>world) (?P<who>her)", m)
     doAssert m.groupCapture("greet", text) == "hello"
     doAssert m.groupCapture("who", text) == "her"
 


### PR DESCRIPTION
this PR improves capturing groups usage by
- add groupsNames: to get list of group names
- add groupsByName: the text of all capturing groups with a certain name
- add groupByName:  text of the first capturing group

not sure if i should return the iterator and leave `toSeq` call to the user or not.