### PR TITLE
findAll fix #13

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -418,6 +418,9 @@ when canUseMacro:
   ): bool {.inline, raises: [].} =
     findImpl()
 
+template findOneImpl: untyped {.dirty.} =
+  matchImpl(s, pattern, m, {mfFindMatch, mfFindAllMatch}, i)
+
 iterator findAll*(
   s: string,
   pattern: Regex,
@@ -440,7 +443,7 @@ iterator findAll*(
   var c: Rune
   var m: RegexMatch
   while i < len(s):
-    if not find(s, pattern, m, i):
+    if not findOneImpl():
       break
     if i < m.boundaries.b+1:
       i = m.boundaries.b+1

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -515,29 +515,6 @@ iterator split*(s: string, sep: Regex): string {.inline, raises: [].} =
         continue
     yield substr(s, first, last-1)
     first = m.boundaries.b+1
-    
-  #[
-  while last <= s.len:
-    if not find(s, sep, m, last):
-      last = s.len+1
-    elif m.boundaries.b >= m.boundaries.a:
-      last = m.boundaries.a
-    else:  # zero match
-      last = m.boundaries.a
-      # skip first empty match
-      if last == 0 and skipFirst:
-        skipFirst = false
-        runeIncAt(s, last)
-        continue
-    yield substr(s, first, last-1)
-    first = m.boundaries.b+1
-    if last > len(s): break
-    if m.boundaries.b >= m.boundaries.a:
-      doAssert last < m.boundaries.b+1
-      last = m.boundaries.b+1
-    else:  # zero match
-      runeIncAt(s, last)
-  ]#
 
 func split*(s: string, sep: Regex): seq[string] {.inline, raises: [].} =
   ## return not matched substrings

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -536,26 +536,30 @@ func splitIncl*(s: string, sep: Regex): seq[string] {.inline, raises: [].} =
     doAssert parts == expected
 
   var
-    first, last = 0
+    first, last, i = 0
+    skipFirst = true
     m: RegexMatch
-  while last <= s.len:
-    first = last
-    while last <= s.len:
-      if not find(s, sep, m, last):
-        last = s.len + 1
-        break
-      if m.boundaries.a <= m.boundaries.b:
-        last = m.boundaries.a
-        break
-      # empty match
-      runeIncAt(s, last)
+  while i <= len(s):
+    if not find(s, sep, m, i):
+      i = s.len+1
+      last = s.len+1
+    elif m.boundaries.b >= m.boundaries.a:
+      doAssert i < m.boundaries.b+1
+      i = m.boundaries.b+1
+      last = m.boundaries.a
+    else:  # empty match
+      doAssert i <= m.boundaries.a
+      i = m.boundaries.a
+      runeIncAt(s, i)
+      last = m.boundaries.a
+      if last == 0 and skipFirst:  # edge case
+        skipFirst = false
+        continue
     result.add substr(s, first, last-1)
+    first = m.boundaries.b+1
     for g in 0 ..< m.groupsCount:
       for sl in m.group(g):
         result.add substr(s, sl.a, sl.b)
-    if m.boundaries.a <= m.boundaries.b:
-      doAssert last < m.boundaries.b+1
-      last = m.boundaries.b+1
 
 func startsWith*(
   s: string, pattern: Regex, start = 0

--- a/src/regex/nfamacro.nim
+++ b/src/regex/nfamacro.nim
@@ -434,6 +434,15 @@ template findMatch: untyped {.dirty.} =
     m.boundaries = smA[0][2]
     return true
 
+func bwRuneAt(s: string, n: int): Rune =
+  ## Take rune ending at ``n``
+  doAssert n >= 0
+  doAssert n <= s.len-1
+  var n = n
+  while n > 0 and s[n].ord shr 6 == 0b10:
+    dec n
+  fastRuneAt(s, n, result, false)
+
 func matchImpl*(
   text: string,
   regex: static Regex,
@@ -458,6 +467,9 @@ func matchImpl*(
   smA = newSubmatches(regex.nfa.len)
   smB = newSubmatches(regex.nfa.len)
   smA.add((0'i16, -1'i32, start .. start-1))
+  when mfFindMatch in flags:
+    if 0 <= start-1 and start-1 <= len(text)-1:
+      cPrev = bwRuneAt(text, start-1).int32
   while i < len(text):
     fastRuneAt(text, i, c, true)
     #c = text[i].Rune

--- a/src/regex/nfamatch.nim
+++ b/src/regex/nfamatch.nim
@@ -86,6 +86,14 @@ template findMatch: untyped {.dirty.} =
     m.boundaries = smA[0][2]
     return true
 
+func bwRuneAt(s: string, n: int): Rune =
+  ## Take rune ending at ``n``
+  doAssert n > 0
+  var n = n
+  while n > 0 and s[n].ord shr 6 == 0b10:
+    dec n
+  fastRuneAt(s, n, result, false)
+
 func matchImpl*(
   text: string,
   regex: Regex,
@@ -104,6 +112,9 @@ func matchImpl*(
   smA = newSubmatches(regex.nfa.len)
   smB = newSubmatches(regex.nfa.len)
   smA.add((0'i16, -1'i32, start .. start-1))
+  when mfFindAllMatch in flags:
+    if start > 0:
+      cPrev = bwRuneAt(text, start).int32
   while i < len(text):
     fastRuneAt(text, i, c, true)
     when mfShortestMatch in flags:

--- a/src/regex/nfamatch.nim
+++ b/src/regex/nfamatch.nim
@@ -88,7 +88,8 @@ template findMatch: untyped {.dirty.} =
 
 func bwRuneAt(s: string, n: int): Rune =
   ## Take rune ending at ``n``
-  doAssert n > 0
+  doAssert n >= 0
+  doAssert n <= s.len-1
   var n = n
   while n > 0 and s[n].ord shr 6 == 0b10:
     dec n
@@ -112,9 +113,9 @@ func matchImpl*(
   smA = newSubmatches(regex.nfa.len)
   smB = newSubmatches(regex.nfa.len)
   smA.add((0'i16, -1'i32, start .. start-1))
-  when mfFindAllMatch in flags:
-    if start > 0:
-      cPrev = bwRuneAt(text, start).int32
+  when mfFindMatch in flags:
+    if 0 <= start-1 and start-1 <= len(text)-1:
+      cPrev = bwRuneAt(text, start-1).int32
   while i < len(text):
     fastRuneAt(text, i, c, true)
     when mfShortestMatch in flags:

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -54,7 +54,6 @@ type
     mfShortestMatch
     mfNoCaptures
     mfFindMatch
-    mfFindAllMatch
   MatchFlags* = set[MatchFlag]
   RegexMatch* = object
     ## result from matching operations

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -54,6 +54,7 @@ type
     mfShortestMatch
     mfNoCaptures
     mfFindMatch
+    mfFindAllMatch
   MatchFlags* = set[MatchFlag]
   RegexMatch* = object
     ## result from matching operations

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1635,14 +1635,35 @@ test "tmisc2":
     check(not match("1", re1))
   block:  # issue #61
     const a = "void __mingw_setusermatherr (int (__attribute__((__cdecl__)) *)(struct _exception *));"
-    doAssert replace(a, re"__attribute__[ ]*\(\(.*?\)\)([ ,;])", "$1") ==
+    check replace(a, re"__attribute__[ ]*\(\(.*?\)\)([ ,;])", "$1") ==
       "void __mingw_setusermatherr (int ( *)(struct _exception *));"
-    doAssert replace(a, re"__attribute__[ ]*\(\(.*?\)\)(.*?[ ,;])", "$1") ==
+    check replace(a, re"__attribute__[ ]*\(\(.*?\)\)(.*?[ ,;])", "$1") ==
       "void __mingw_setusermatherr (int ( *)(struct _exception *));"
-    doAssert find(a, re"__attribute__[ ]*\(\(.*?\)\)([ ,;])", m) and
+    check find(a, re"__attribute__[ ]*\(\(.*?\)\)([ ,;])", m) and
       a[m.boundaries] == "__attribute__((__cdecl__)) "
-    doAssert find(a, re"__attribute__[ ]*\(\(.*?\)\)(.*?[ ,;])", m) and
+    check find(a, re"__attribute__[ ]*\(\(.*?\)\)(.*?[ ,;])", m) and
       a[m.boundaries] == "__attribute__((__cdecl__)) "
     # non-greedy
-    doAssert find(a, re"__attribute__[ ]*\(\(.*\)\)([ ,;])", m) and
+    check find(a, re"__attribute__[ ]*\(\(.*\)\)([ ,;])", m) and
       a[m.boundaries] == "__attribute__((__cdecl__)) *)(struct _exception *));"
+  block:  # issue #13
+    const input = """foo
+              bar
+      baxx
+                bazz
+    """
+    const expected = """//foo
+//              bar
+//      baxx
+//                bazz
+//    """
+    check replace(input, re"(?m)^", "//") == expected
+  check replace("bar", re"^", "foo") == "foobar"
+  check replace("foo", re"$", "bar") == "foobar"
+  check(not find("foobarbar", re"^bar", m, start=3))
+  check find("foobar\nbar", re"(?m)^bar", m, start=3) and
+    m.boundaries == 7 .. 9
+  check find("foo\nbar\nbar", re"(?m)^bar", m, start=3) and
+    m.boundaries == 4 .. 6
+  check find("foo\nbar\nbar", re"(?m)^bar", m, start=4) and
+    m.boundaries == 4 .. 6

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1748,3 +1748,5 @@ test "tmisc2":
   check split("iaiaiai", re"i") == @["", "a", "a", "a", ""]
   check split("aiaia", re"i") == @["a", "a", "a"]
   check split("aaa", re"a") == @["", "", "", ""]
+  check split("a\na\na", re"(?m)^") == @["a\n", "a\n", "a"]
+  check split("\n\n", re"(?m)^") == @["\n", "\n"]

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1667,3 +1667,16 @@ test "tmisc2":
     m.boundaries == 4 .. 6
   check find("foo\nbar\nbar", re"(?m)^bar", m, start=4) and
     m.boundaries == 4 .. 6
+  block:
+    # The bounds must contain the empty match index
+    check find("foo\nbar\nbar", re"(?m)^", m) and
+      m.boundaries == 0 .. -1
+    check find("foo\nbar\nbar", re"(?m)^", m, start=1) and
+      m.boundaries == 4 .. 3
+    check find("foo\nbar\nbar", re"(?m)^", m, start=4) and
+      m.boundaries == 4 .. 3
+    check find("foo\nbar\nbar", re"(?m)^", m, start=5) and
+      m.boundaries == 8 .. 7
+    check find("foo\nbar\nbar", re"(?m)^", m, start=8) and
+      m.boundaries == 8 .. 7
+    check(not find("foo\nbar\nbar", re"(?m)^", m, start=9))

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1660,6 +1660,18 @@ test "tmisc2":
     check replace(input, re"(?m)^", "//") == expected
   check replace("bar", re"^", "foo") == "foobar"
   check replace("foo", re"$", "bar") == "foobar"
+  block:
+    const input = """foo
+              bar
+      baxx
+                bazz
+    """
+    const expected = """foo//
+              bar//
+      baxx//
+                bazz//
+    //"""
+    check replace(input, re"(?m)$", "//") == expected
   check(not find("foobarbar", re"^bar", m, start=3))
   check find("foobar\nbar", re"(?m)^bar", m, start=3) and
     m.boundaries == 7 .. 9

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -911,7 +911,7 @@ test "tsplitIncl":
   check "12".splitIncl(re"(\d)") == @["", "1", "", "2", ""]
   check splitIncl("aΪⒶ弢", re"(\w)") ==
     @["", "a", "", "Ϊ", "", "Ⓐ", "", "弢", ""]
-  check splitIncl("aΪⒶ弢", re"") == @["aΪⒶ弢"]
+  check splitIncl("aΪⒶ弢", re"") == @["a", "Ϊ", "Ⓐ", "弢"]
   check splitIncl("...words, words...", re"(\W+)") ==
     @["", "...", "words", ", ", "words", "...", ""]
   check splitIncl("Words, words, words.", re"(\W+)") ==
@@ -924,7 +924,7 @@ test "tsplitIncl":
   check splitIncl("AAA :   : BBB", re"\s*:\s*") == @["AAA", "", "BBB"]
   check splitIncl("", re",") == @[""]
   check splitIncl(",,", re",") == @["", "", ""]
-  check splitIncl("abc", re"") == @["abc"]
+  check splitIncl("abc", re"") == @["a", "b", "c"]
   check splitIncl(",a,Ϊ,Ⓐ,弢,", re",") ==
     @["", "a", "Ϊ", "Ⓐ", "弢", ""]
   check splitIncl("弢", re"\xAF") == @["弢"]  # "弢" == "\xF0\xAF\xA2\x94"

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -879,7 +879,7 @@ test "tsplit":
   check split("AAA :   : BBB", re"\s*:\s*") == @["AAA", "", "BBB"]
   check split("", re",") == @[""]
   check split(",,", re",") == @["", "", ""]
-  check split("abc", re"") == @["abc"]
+  check split("abc", re"") == @["a", "b", "c"]
   check split(",a,Ϊ,Ⓐ,弢,", re",") ==
     @["", "a", "Ϊ", "Ⓐ", "弢", ""]
   check split("弢", re"\xAF") == @["弢"]  # "弢" == "\xF0\xAF\xA2\x94"
@@ -1714,3 +1714,37 @@ test "tmisc2":
   # this should be valid though
   check match("", re"(?m)^", m)
   check match("", re"(?m)$", m)
+  block:
+    const input = """foo
+              bar
+      baxx
+                bazz
+    """
+    const expected = @[
+      "foo\n",
+      "              bar\n",
+      "      baxx\n",
+      "                bazz\n",
+      "    "
+    ]
+    check split(input, re"(?m)^") == expected
+  block:
+    const input = """foo
+              bar
+      baxx
+                bazz
+    """
+    const expected = @[
+      "foo",
+      "\n              bar",
+      "\n      baxx",
+      "\n                bazz",
+      "\n    "
+    ]
+    check split(input, re"(?m)$") == expected
+  check split("acb\nb\nc\n", re"(?m)^") == @["acb\n", "b\n", "c\n"]
+  check split("a b", re"\b") == @["a", " ", "b"]
+  check split("ab", re"\b") == @["ab"]
+  check split("iaiaiai", re"i") == @["", "a", "a", "a", ""]
+  check split("aiaia", re"i") == @["a", "a", "a"]
+  check split("aaa", re"a") == @["", "", "", ""]

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1680,3 +1680,25 @@ test "tmisc2":
     check find("foo\nbar\nbar", re"(?m)^", m, start=8) and
       m.boundaries == 8 .. 7
     check(not find("foo\nbar\nbar", re"(?m)^", m, start=9))
+    check find("foo\nbar\nbar", re"(?m)$", m) and
+      m.boundaries == 3 .. 2
+    check find("foo\nbar\nbar", re"(?m)$", m, start=3) and
+      m.boundaries == 3 .. 2
+    check find("foo\nbar\nbar", re"(?m)$", m, start=4) and
+      m.boundaries == 7 .. 6
+    check find("foo\nbar\nbar", re"(?m)$", m, start=7) and
+      m.boundaries == 7 .. 6
+    check find("foo\nbar\nbar", re"(?m)$", m, start=8) and
+      m.boundaries == 11 .. 10
+    check find("foo\nbar\nbar", re"(?m)$", m, start=11) and
+      m.boundaries == 11 .. 10
+    # start is out of bounds, but this is what Nim's re
+    # does, nre throws an error
+    check find("foo\nbar\nbar", re"(?m)$", m, start=12) and
+      m.boundaries == 12 .. 11
+  # XXX make this return false?
+  check match("abc", re"(?m)$", m, start=50)
+  check match("abc", re"(?m)^", m, start=50)
+  # this should be valid though
+  check match("", re"(?m)^", m)
+  check match("", re"(?m)$", m)


### PR DESCRIPTION
Fixes #13 
Fixes #29 (except for the last example)

~~This is a hack~~ not a hack, since `find` needs this anyway (to keep the same behaviour as re/nre). A better fix would not call `find` in `findAll` repeatedly, it'd implement the `matchImpl` as an iterator. Also, that change would enable data stream input for `findAll` (issue #14). However, that's a more involved change as it'd require to prune the capture tree after some threshold (i.e: the first X nodes are no longer useful when the first parallel/submatch state boundaries are > X) of N KiB, and discard overlapping submatch states after a match.
