### PR TITLE
'find' is not used in nfamatch

### DIFF
--- a/src/regex/nfamatch.nim
+++ b/src/regex/nfamatch.nim
@@ -7,7 +7,6 @@
 
 import std/unicode
 import std/tables
-from std/strutils import find
 
 import nodematch
 import nodetype


### PR DESCRIPTION
Avoiding warning about std/strutils import of find not being required.