### PR TITLE
Gen dot files for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nimble test
 
 ## Debugging
 
-Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the compiled file. A dot file can be viewed with [Graphviz](https://dreampuf.github.io/GraphvizOnline/).
+Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the nim file. A dot file can be viewed in [Graphviz](https://dreampuf.github.io/GraphvizOnline/). Requires Nim +1.4.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nimble test
 
 ## Debugging
 
-Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the nim file. A dot file can be viewed in [Graphviz](https://dreampuf.github.io/GraphvizOnline/).
+Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the nim file. A dot file can be viewed in [Graphviz](https://dreampuf.github.io/GraphvizOnline/). Requires Nim +1.2.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Nim +0.19.0
 nimble test
 ```
 
+## Debugging
+
+Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the compiled file. A dot file can be viewed with [Graphviz](https://dreampuf.github.io/GraphvizOnline/).
+
 ## LICENSE
 
 MIT

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nimble test
 
 ## Debugging
 
-Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the nim file. A dot file can be viewed in [Graphviz](https://dreampuf.github.io/GraphvizOnline/). Requires Nim +1.4.
+Compile with `-d:regexDotDir:.` to generate [dot files](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) of the regexes (NFAs) within the nim file. A dot file can be viewed in [Graphviz](https://dreampuf.github.io/GraphvizOnline/).
 
 ## LICENSE
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -922,6 +922,7 @@ proc toString(pattern: Regex): string {.used.} =
 when isMainModule:
   import ./regex/parser
   import ./regex/exptransformation
+  import ./regex/dotgraph
 
   func toAtoms(s: string): string =
     var groups: GroupsCapture
@@ -1105,6 +1106,15 @@ when isMainModule:
 
   doAssert match("abcabcabc", re"(?:(?:abc)){3}")
   doAssert match("abcabcabc", re"((abc)){3}")
+
+  doAssert graph(re"^a+$") == """digraph graphname {
+    0 [label="q0";color=blue];
+    1 [label="q1";color=black];
+    2 [label="q2";color=blue];
+    0 -> 1 [label="a, {^}, i=0"];
+    1 -> 1 [label="a, i=0"];1 -> 2 [label="{eoe}, {$}, i=1"];
+}
+"""
 
   # subset of tests.nim
   proc raisesMsg(pattern: string): string =

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -20,7 +20,7 @@ func reImpl*(s: string): Regex {.inline.} =
     groupsCount: groups.count,
     namedGroups: groups.names,
     litOpt: opt)
-  when defined(regexDotDir):
+  when defined(regexDotDir) and (NimMajor, NimMinor) >= (1, 2):
     const regexDotDir {.strdefine.} = ""
     graphToFile(result, regexDotDir)
 

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -3,6 +3,8 @@ import ./exptransformation
 import ./nfatype
 import ./nfa
 import ./litopt
+when defined(regexDotDir):
+  import ./dotgraph
 
 func reImpl*(s: string): Regex {.inline.} =
   var groups: GroupsCapture
@@ -18,6 +20,9 @@ func reImpl*(s: string): Regex {.inline.} =
     groupsCount: groups.count,
     namedGroups: groups.names,
     litOpt: opt)
+  when defined(regexDotDir):
+    const regexDotDir {.strdefine.} = ""
+    graphToFile(result, regexDotDir)
 
 func reCt*(s: string): Regex {.compileTime.} =
   reImpl(s)

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -20,7 +20,7 @@ func reImpl*(s: string): Regex {.inline.} =
     groupsCount: groups.count,
     namedGroups: groups.names,
     litOpt: opt)
-  when defined(regexDotDir):
+  when defined(regexDotDir) and (NimMajor, NimMinor) >= (1, 4):
     const regexDotDir {.strdefine.} = ""
     graphToFile(result, regexDotDir)
 

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -20,7 +20,7 @@ func reImpl*(s: string): Regex {.inline.} =
     groupsCount: groups.count,
     namedGroups: groups.names,
     litOpt: opt)
-  when defined(regexDotDir) and (NimMajor, NimMinor) >= (1, 4):
+  when defined(regexDotDir):
     const regexDotDir {.strdefine.} = ""
     graphToFile(result, regexDotDir)
 

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -37,9 +37,9 @@ func graph*(nfa: Nfa, tns: Transitions): string =
 func graph*(regex: Regex): string =
   result = graph(regex.nfa, regex.transitions)
 
-when (NimMajor, NimMinor) >= (1, 4):
+when defined(regexDotDir):
   func graphToFile*(regex: Regex, dir: string) =
-    {.cast(noSideEffect).}:
+    {.noSideEffect.}:
       if dir.len > 0:
         let content = graph(regex)
         let fname = $hash(content) & ".dot"

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -37,12 +37,13 @@ func graph*(nfa: Nfa, tns: Transitions): string =
 func graph*(regex: Regex): string =
   result = graph(regex.nfa, regex.transitions)
 
-func graphToFile*(regex: Regex, dir: string) =
-  {.noSideEffect.}:
-    if dir.len > 0:
-      let content = graph(regex)
-      let fname = $hash(content) & ".dot"
-      try:
-        writeFile(dir / fname, content)
-      except IOError:
-        debugEcho "write file error"
+when (NimMajor, NimMinor) >= (1, 2):
+  func graphToFile*(regex: Regex, dir: string) =
+    {.noSideEffect.}:
+      if dir.len > 0:
+        let content = graph(regex)
+        let fname = $hash(content) & ".dot"
+        try:
+          writeFile(dir / fname, content)
+        except IOError:
+          debugEcho "write file error"

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -37,8 +37,7 @@ func graph*(nfa: Nfa, tns: Transitions): string =
 func graph*(regex: Regex): string =
   result = graph(regex.nfa, regex.transitions)
 
-# cast(noSideEffect) only works in recent Nim's versions
-when defined(regexDotDir):
+when (NimMajor, NimMinor) >= (1, 4):
   func graphToFile*(regex: Regex, dir: string) =
     {.cast(noSideEffect).}:
       if dir.len > 0:

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -1,0 +1,50 @@
+import std/hashes
+import std/os
+import std/strutils
+
+import ./nfa
+import ./nfatype
+import ./nodetype
+
+func color(n: Node): string =
+  case n.kind
+  of matchableKind: "black"
+  else: "blue"
+
+func graph*(nfa: Nfa, tns: Transitions): string =
+  result = "digraph graphname {\n"
+  let tab = "    "
+  for i, n in pairs nfa:
+    result.add tab
+    result.add($i & " [label=\"q" & $i & "\";color=" & n.color & "];")
+    result.add '\n'
+  for i, n in pairs nfa:
+    if n.next.len == 0:
+      continue
+    result.add tab
+    for i2, n2 in pairs n.next:
+      var t = ""
+      if tns.allZ[i][i2] > -1:
+        for i3, z in pairs tns.z[tns.allZ[i][i2]]:
+          if i3 > 0: t &= ", "
+          t &= $z
+        t = ", {" & t & "}"
+      let label = ($nfa[n2] & t & ", i=" & $i2).replace(r"\", r"\\")
+      result.add($i & " -> " & $n2 & " [label=\"" & label & "\"];")
+    result.add '\n'
+  result.add "}\n"
+
+func graph*(regex: Regex): string =
+  result = graph(regex.nfa, regex.transitions)
+
+# cast(noSideEffect) only works in recent Nim's versions
+when defined(regexDotDir):
+  func graphToFile*(regex: Regex, dir: string) =
+    {.cast(noSideEffect).}:
+      if dir.len > 0:
+        let content = graph(regex)
+        let fname = $hash(content) & ".dot"
+        try:
+          writeFile(dir / fname, content)
+        except IOError:
+          debugEcho "write file error"

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -37,13 +37,12 @@ func graph*(nfa: Nfa, tns: Transitions): string =
 func graph*(regex: Regex): string =
   result = graph(regex.nfa, regex.transitions)
 
-when defined(regexDotDir):
-  func graphToFile*(regex: Regex, dir: string) =
-    {.noSideEffect.}:
-      if dir.len > 0:
-        let content = graph(regex)
-        let fname = $hash(content) & ".dot"
-        try:
-          writeFile(dir / fname, content)
-        except IOError:
-          debugEcho "write file error"
+func graphToFile*(regex: Regex, dir: string) =
+  {.noSideEffect.}:
+    if dir.len > 0:
+      let content = graph(regex)
+      let fname = $hash(content) & ".dot"
+      try:
+        writeFile(dir / fname, content)
+      except IOError:
+        debugEcho "write file error"

--- a/src/regex/nodetype.nim
+++ b/src/regex/nodetype.nim
@@ -232,38 +232,41 @@ const
     reGroupStart,
     reGroupEnd}
 
-func toString*(n: Node): string =
+func `$`*(n: Node): string =
   ## return the string representation
   ## of a `Node`. The string is always
   ## equivalent to the original
   ## expression but not necessarily equal
-  # Note this is not complete. Just
-  # what's needed for debugging so far
   case n.kind
-  of reZeroOrMore,
-      reOneOrMore,
-      reZeroOrOne:
-    if not n.isGreedy:
-      n.cp.toUTF8 & "?"
-    else:
-      n.cp.toUTF8
-  of reRepRange:
-    "#"  # Invalid
-  of reStart:
-    "\\A"
-  of reEnd:
-    "\\z"
-  of reWordBoundary:
-    "\\b"
-  of reNotWordBoundary:
-    "\\B"
-  of shorthandKind:
-    '\\' & n.cp.toUTF8
+  of reChar, reCharCi: $n.cp
+  of reJoiner: "~"
+  of reGroupStart: "("
+  of reGroupEnd: ")"
+  of reOr: "|"
+  of reZeroOrMore: "*" & (if n.isGreedy: "" else: "?")
+  of reOneOrMore: "+" & (if n.isGreedy: "" else: "?")
+  of reZeroOrOne: "?" & (if n.isGreedy: "" else: "?")
+  of reRepRange: "{" & $n.min & "," & $n.max & "}"
+  of reStartSym, reStartSymML: "^"
+  of reEndSym, reEndSymML: "$"
+  of reStart: r"\A"
+  of reEnd: r"\z"
+  of reWordBoundary, reWordBoundaryAscii: r"\b"
+  of reNotWordBoundary, reNotWordBoundaryAscii: r"\B"
+  of reWord, reWordAscii: r"\w"
+  of reDigit, reDigitAscii: r"\d"
+  of reWhiteSpace, reWhiteSpaceAscii: r"\s"
+  of reUCC: r"\pN"
+  of reNotAlphaNum, reNotAlphaNumAscii: r"\W"
+  of reNotDigit, reNotDigitAscii: r"\D"
+  of reNotWhiteSpace, reNotWhiteSpaceAscii: r"\S"
+  of reNotUCC: r"\PN"
+  of reAny, reAnyNl, reAnyAscii, reAnyNlAscii: "."
   of reInSet, reNotSet:
     var str = ""
-    str.add('[')
+    str.add '['
     if n.kind == reNotSet:
-      str.add('^')
+      str.add '^'
     var
       cps = newSeq[Rune](n.cps.len)
       i = 0
@@ -271,21 +274,21 @@ func toString*(n: Node): string =
       cps[i] = cp
       inc i
     for cp in cps.sorted(cmp):
-      str.add(cp.toUTF8)
+      str.add $cp
     for sl in n.ranges:
-      str.add(sl.a.toUTF8 & '-' & sl.b.toUTF8)
+      str.add($sl.a & '-' & $sl.b)
     for nn in n.shorthands:
-      str.add(nn.toString)
-    str.add(']')
+      str.add $nn
+    str.add ']'
     str
-  of reSkip:
-    "SKIP"
-  of reEOE:
-    "EOE"
-  else:
-    n.cp.toUTF8
+  of reLookahead: "(?=...)"
+  of reLookbehind: "(?<=...)"
+  of reNotLookahead: "(?!...)"
+  of reNotLookbehind: "(?<!...)"
+  of reSkip: r"{skip}"
+  of reEoe: r"{eoe}"
 
 func toString*(n: seq[Node]): string =
   result = newStringOfCap(n.len)
   for nn in n:
-    result.add(nn.toString)
+    result.add $nn


### PR DESCRIPTION
Defines a `regexDotDir` compile parameter to generate a dot file to visualize the regex NFA.