### PR TITLE
followup now that https://github.com/nim-lang/Nim/issues/15511 was fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [0.19.6, 0.20.0, 0.20.2, 1.0.0, 1.0.2, 1.0.4, 1.0.10, 1.2.0, 1.2.2, 1.2.4, 1.2.6, 1.2.8, 1.4.0, 1.4.2]
+        # xxx trim to on use latest in each branch eg 1.0.10, 1.2.8 etc
+        nim: [1.0.0, 1.0.2, 1.0.4, 1.0.10, 1.2.0, 1.2.2, 1.2.4, 1.2.6, 1.2.8, 1.4.0, 1.4.2, 1.4.4]
     steps:
     - uses: actions/checkout@v2
     - name: Run Tests

--- a/regex.nimble
+++ b/regex.nimble
@@ -7,7 +7,7 @@ license = "MIT"
 srcDir = "src"
 skipDirs = @["tests", "bench", "docs"]
 
-requires "nim >= 0.19.6"
+requires "nim >= 1.0.0"
 requires "unicodedb >= 0.7.2"
 
 task test, "Test":
@@ -33,4 +33,5 @@ task test, "Test":
     exec "nim doc -o:./docs/ugh/ugh.html ./src/regex.nim"
 
 task docs, "Docs":
+  # xxx use --outdir:docs
   exec "nim doc --project -o:./docs ./src/regex.nim"

--- a/src/regex/nfa.nim
+++ b/src/regex/nfa.nim
@@ -193,6 +193,10 @@ func teClosure(
   for s in eNfa.s[state].next:
     teClosure(result, eNfa, s, processing, zclosure)
 
+when (NimMajor, NimMinor, NimPatch) < (1,4,0) and not declared(IndexDefect):
+  # avoids a warning
+  type IndexDefect = IndexError
+
 func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
   ## Remove e-transitions and return
   ## remaining state transtions and
@@ -220,7 +224,7 @@ func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
   while qw.len > 0:
     try:
       qa = qw.popLast()
-    except IndexError:
+    except IndexDefect:
       doAssert false
     closure.setLen 0
     teClosure(closure, eNfa, qa, processing)

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -5,6 +5,7 @@ when NimMajor >= 1:
 import std/unicode
 import std/sets
 from std/algorithm import sorted
+from std/sequtils import toSeq
 
 import pkg/unicodedb/properties
 
@@ -186,14 +187,7 @@ func initSkipNode*(next: openArray[int16]): Node =
   ## while traversing the NFA
   result = Node(
     kind: reSkip,
-    cp: "#".toRune)
-  when (NimMajor, NimMinor, NimPatch) >= (1,5,1) or (not defined(gcOrc) and not defined(gcArc)):
-    # refs https://github.com/nim-lang/Nim/issues/15511
-    result.next.add next
-  else:
-    result.next.setLen next.len
-    for i in 0..<next.len:
-      result.next[i] = next[i]
+    cp: "#".toRune, next: toSeq(next))
 
 func isEmpty*(n: Node): bool =
   ## check if a set ``Node`` is empty

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -187,12 +187,13 @@ func initSkipNode*(next: openArray[int16]): Node =
   result = Node(
     kind: reSkip,
     cp: "#".toRune)
-  when false:
-    # pending https://github.com/nim-lang/Nim/issues/15511#issuecomment-719952709
+  when (NimMajor, NimMinor, NimPatch) >= (1,5,1) or (not defined(gcOrc) and not defined(gcArc)):
+    # refs https://github.com/nim-lang/Nim/issues/15511
     result.next.add next
   else:
-    for ai in next:
-      result.next.add ai
+    result.next.setLen next.len
+    for i in 0..<next.len:
+      result.next[i] = next[i]
 
 func isEmpty*(n: Node): bool =
   ## check if a set ``Node`` is empty


### PR DESCRIPTION
* closes https://github.com/nitely/nim-regex/issues/81
* addresses https://github.com/nitely/nim-regex/pull/82#issuecomment-719958928
* remove a warning

I've dropped support for nim < 1.0 otherwise the change i did via toSeq doesn't work, if for some reason that's not desirable I can use a `when` to support it. I dont' see much value in supporting nim < 1.0 at this point though (more opportunities for simplifying code).