### PR TITLE
Literals substring optimization

### DIFF
--- a/bench/bench.nim
+++ b/bench/bench.nim
@@ -180,8 +180,7 @@ benchRelative(regex_url_find_all, m):
   for i in 0 ..< m:
     for _ in regex.findAll(bench_text, url_find_all):
       d += 1
-  #echo d
-  #doAssert d == 5295
+  doAssert d == 5295
   doNotOptimizeAway(d)
 
 when true:

--- a/bench/bench.nim
+++ b/bench/bench.nim
@@ -163,6 +163,27 @@ benchRelative(regex_ip_find_all, m):
   doAssert d == 5
   doNotOptimizeAway(d)
 
+var url_find_all_re = re.re"https?://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?"
+
+bench(re_url_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in re.findAll(bench_text, url_find_all_re):
+      d += 1
+  doAssert d == 5295
+  doNotOptimizeAway(d)
+
+const url_find_all = regex.re2"https?://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?"
+
+benchRelative(regex_url_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in regex.findAll(bench_text, url_find_all):
+      d += 1
+  #echo d
+  #doAssert d == 5295
+  doNotOptimizeAway(d)
+
 when true:
   bench(runes, m):
     var d = 0

--- a/bench/bench.nim
+++ b/bench/bench.nim
@@ -203,6 +203,26 @@ benchRelative(regex_url_find_all, m):
   doAssert d == 5295
   doNotOptimizeAway(d)
 
+var unicode_find_all_re = re.re"\smůžete\s"
+
+bench(re_unicode_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in re.findAll(bench_text, unicode_find_all_re):
+      d += 1
+  doAssert d == 25
+  doNotOptimizeAway(d)
+
+const unicode_find_all = regex.re2"\smůžete\s"
+
+benchRelative(regex_unicode_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in regex.findAll(bench_text, unicode_find_all):
+      d += 1
+  doAssert d == 25
+  doNotOptimizeAway(d)
+
 when true:
   bench(runes, m):
     var d = 0

--- a/bench/bench.nim
+++ b/bench/bench.nim
@@ -163,6 +163,26 @@ benchRelative(regex_ip_find_all, m):
   doAssert d == 5
   doNotOptimizeAway(d)
 
+var sql_find_all_re = re.re"mysql://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?"
+
+bench(re_sql_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in re.findAll(bench_text, sql_find_all_re):
+      d += 1
+  doAssert d == 4
+  doNotOptimizeAway(d)
+
+const sql_find_all = regex.re2"mysql://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?"
+
+benchRelative(regex_sql_find_all, m):
+  var d = 0
+  for i in 0 ..< m:
+    for _ in regex.findAll(bench_text, sql_find_all):
+      d += 1
+  doAssert d == 4
+  doNotOptimizeAway(d)
+
 var url_find_all_re = re.re"https?://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?"
 
 bench(re_url_find_all, m):

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -13,7 +13,7 @@ func reImpl*(s: string): Regex {.inline.} =
     .parse
     .transformExp(groups)
   let nfa = rpn.nfa2()
-  let opt = rpn.litopt2()
+  let opt = rpn.litopt3()
   result = Regex(
     nfa: nfa,
     groupsCount: groups.count,

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -484,17 +484,6 @@ when isMainModule:
   doAssert lits"abc*d" == "ab"
   doAssert lits"abc+d" == "ab"
 
-  block:
-    let skipChars = {'(', ')', '+', '?', '*', '[', ']', '\\'}
-    var i = 0
-    for cp in 0 .. 127:
-      if cp.char in skipChars:
-        continue
-      doAssert lits(r"" & cp.char) == ""
-      inc i
-    doAssert i == 128-skipChars.len
-    doAssert lits(128.Rune.toUtf8).len == 2
-
   doAssert r"abc".prefix.toString == r"".toNfa.toString
   doAssert r"\dabc".prefix.toString == r"\d".toNfa.toString
   doAssert r"abcab".prefix.toString == r"".toNfa.toString
@@ -506,6 +495,7 @@ when isMainModule:
   doAssert r"\w@".prefix.toString == r"\w".toNfa.toString
   doAssert r"\w@&%".prefix.toString == r"\w".toNfa.toString
   doAssert r"\w\d@&%".prefix.toString == r"\d\w".toNfa.toString
+  doAssert r"\w\d@&%".prefix.toString == "[#, [d, [w, eoe]]]"
 
   doAssert r"(a|b)xyz".prefix.toString == r"(a|b)".toNfa.toString
   doAssert r"(a|ab)\w@&%".prefix.toString == r"\w(a|ba)".toNfa.toString
@@ -531,5 +521,17 @@ when isMainModule:
   doAssert r"\w*\d+?@".prefix.toString == r"\d+\w*".toNfa.toString
   doAssert r"\w*?\d+@".prefix.toString == r"\d+\w*".toNfa.toString
   doAssert r"\w*?\d+?@".prefix.toString == r"\d+\w*".toNfa.toString
+
+  # sanity check
+  block:
+    let skipChars = {'(', ')', '+', '?', '*', '[', ']', '\\'}
+    var i = 0
+    for cp in 0 .. 127:
+      if cp.char in skipChars:
+        continue
+      doAssert lits(r"" & cp.char).len == 0
+      inc i
+    doAssert i == 128-skipChars.len
+    doAssert lits(128.Rune.toUtf8).len == 2
 
   echo "litopt ok"

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -183,12 +183,12 @@ func find(nodes: seq[Node], uid: int): NodeIdx =
       return idx.NodeIdx
   doAssert false
 
-func lits(res: var Lits, exp: RpnExp): bool =
+func lits(exp: RpnExp): Lits =
   template state: untyped = litNfa.s[stateIdx]
-  res.idx = exp.delimiterLit()
-  if res.idx == -1:
-    return false
-  let litUid = exp.s[res.idx].uid
+  result.idx = exp.delimiterLit()
+  if result.idx == -1:
+    return
+  let litUid = exp.s[result.idx].uid
   let litNfa = exp.toLitNfa()
   var lits = newSeq[int16]()
   var stateIdx = litNfa.s.len.int16-1
@@ -218,9 +218,8 @@ func lits(res: var Lits, exp: RpnExp): bool =
   for i in litIdxStart .. litIdxEnd:
     ss.add litNfa.s[lits[i]].cp
   if ss.len > 1:
-    res.idx = find(exp.s, litNfa.s[lits[litIdxStart]].uid)
-    res.s.add ss
-  return true
+    result.idx = find(exp.s, litNfa.s[lits[litIdxStart]].uid)
+    result.s.add ss
 
 func prefix(eNfa: Enfa, uid: NodeUid): Enfa =
   template state0: untyped = eNfa.s.len.int16-1
@@ -280,13 +279,12 @@ func canOpt*(litOpt: LitOpt): bool =
   return litOpt.nfa.s.len > 0
 
 func litopt3*(exp: RpnExp): LitOpt =
-  template litNode: untyped = exp.s[litIdx]
-  var lits: Lits
-  if not lits(lits, exp):
+  template litNode: untyped = exp.s[lits2.idx]
+  let lits2 = exp.lits()
+  if lits2.idx == -1:
     return
-  let litIdx = lits.idx
   result.lit = litNode.cp
-  result.lits = lits.s
+  result.lits = lits2.s
   result.nfa = exp
     .subExps
     .eNfa

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -145,8 +145,7 @@ func lonelyLit(exp: RpnExp): NodeIdx =
   var lits = newSeq[int16]()
   var stateIdx = litNfa.s.len.int16-1
   while state.kind != reEoe:
-    if state.kind == reChar and
-        state.cp.int <= 127:  # XXX support unicode
+    if state.kind == reChar:
       if state.cp notin cpSeen:
         cpSeen.incl state.cp
         lits.add stateIdx
@@ -186,22 +185,24 @@ func lits(exp: RpnExp): Lits =
   for i in countdown(result.idx-1, 0):
     if exp.s[i].kind != reChar:
       break
-    if exp.s[litIdxStart].uid-1 == exp.s[i].uid:
-      litIdxStart = i.NodeIdx
+    if exp.s[litIdxStart].uid-1 != exp.s[i].uid:
+      break
+    litIdxStart = i.NodeIdx
   doAssert litIdxStart <= result.idx
   result.idx = litIdxStart
   var litIdxEnd = litIdxStart
   for i in litIdxStart+1 .. exp.s.len-1:
     if exp.s[i].kind != reChar:
       break
-    if exp.s[litIdxEnd].uid+1 == exp.s[i].uid:
-      litIdxEnd = i.NodeIdx
+    if exp.s[litIdxEnd].uid+1 != exp.s[i].uid:
+      break
+    litIdxEnd = i.NodeIdx
   doAssert litIdxEnd >= litIdxStart
-  if litIdxEnd == litIdxStart:
-    return
-  result.s = ""
+  var lits = ""
   for i in litIdxStart .. litIdxEnd:
-    result.s.add exp.s[i].cp
+    lits.add exp.s[i].cp
+  if lits.len > 1:
+    result.s.add lits
 
 func prefix(eNfa: Enfa, uid: NodeUid): Enfa =
   template state0: untyped = eNfa.s.len.int16-1
@@ -260,18 +261,6 @@ type
 func canOpt*(litOpt: LitOpt): bool =
   return litOpt.nfa.s.len > 0
 
-func litopt2*(exp: RpnExp): LitOpt =
-  template litNode: untyped = exp.s[litIdx]
-  let litIdx = exp.lonelyLit()
-  if litIdx == -1:
-    return
-  result.lit = litNode.cp
-  result.nfa = exp
-    .subExps
-    .eNfa
-    .prefix(litNode.uid)
-    .eRemoval
-
 func litopt3*(exp: RpnExp): LitOpt =
   template litNode: untyped = exp.s[litIdx]
   let lits = exp.lits()
@@ -287,7 +276,6 @@ func litopt3*(exp: RpnExp): LitOpt =
     .eRemoval
 
 when isMainModule:
-  from unicode import toUtf8, `$`
   import parser
   import exptransformation
 
@@ -299,13 +287,19 @@ when isMainModule:
     var groups: GroupsCapture
     rpn(s, groups)
 
-  func lit(s: string): string =
-    let opt = s.rpn.litopt2
-    if not opt.canOpt: return ""
-    return opt.lit.toUtf8
+  func delim(s: string): string =
+    ## Delimiter lit
+    let idx = s.rpn.lonelyLit
+    if idx == -1: return ""
+    return s.rpn.s[idx].cp.toUtf8
+
+  func lits(s: string): string =
+    let opt = s.rpn.litopt3
+    if not opt.canOpt: return
+    return opt.lits
 
   func prefix(s: string): Nfa =
-    let opt = s.rpn.litopt2
+    let opt = s.rpn.litopt3
     if not opt.canOpt: return
     return opt.nfa
 
@@ -342,69 +336,141 @@ when isMainModule:
     var visited: set[int16]
     result = toString(nfa, 0, visited)
 
-  doAssert lit"abc" == "c"
-  doAssert lit"abcab" == "c"
-  doAssert lit"abc\wxyz" == "c"
-  doAssert lit"(abc)+" == ""
-  doAssert lit"(abc)+xyz" == "z"
-  doAssert lit"(abc)*" == ""
-  doAssert lit"(abc)*xyz" == "z"
-  doAssert lit"(a|b)" == ""
-  doAssert lit"(a+|b)" == ""
-  doAssert lit"(a+|b+)" == ""
-  doAssert lit"((abc)|(xyz))" == ""
-  doAssert lit"((abc)+|(xyz)+)" == ""
-  doAssert lit"((abc)*|(xyz)*)" == ""
-  doAssert lit"a?" == ""
-  doAssert lit"a?b" == "b"
-  doAssert lit"a" == "a"
-  doAssert lit"(a|b)xyz" == "z"
-  doAssert lit"(a|bc)xyz" == "z"
-  doAssert lit"(ab|c)xyz" == "z"
-  doAssert lit"a+b" == "b"
-  doAssert lit"a*b" == "b"
-  doAssert lit"b+b" == ""
-  doAssert lit"b*b" == ""
-  doAssert lit"\d+x" == "x"
-  doAssert lit"\d*x" == "x"
-  doAssert lit"\d?x" == "x"
-  doAssert lit"\w+x" == ""
-  doAssert lit"\w*x" == ""
-  doAssert lit"\w?x" == ""
-  doAssert lit"(\w\d)*abc" == ""
-  doAssert lit"(\w\d)+abc" == ""
-  doAssert lit"(\w\d)?abc" == ""
-  doAssert lit"z(x|y)+abc" == "z"
-  doAssert lit"((a|b)c*d?(ef)*\w\d\b@)+" == ""
-  doAssert lit"((a|b)c*d?(ef)*\w\d\b@)+&%" == "%"
-  doAssert lit"((a|b)c*d?(ef)*\w\d\b)+@&%" == "%"
-  doAssert lit"((a|b)c*d?(ef)*\w\d\bx)+" == ""
-  doAssert lit"((a|b)c*d?(ef)*\w\d\bx)+yz" == ""
-  doAssert lit"((a|b)c*d?(ef)*\w\d\b)+xyz" == ""
-  doAssert lit"^a?" == ""
-  doAssert lit"a?$" == ""
-  doAssert lit"(?m)^" == ""  # XXX \n
-  doAssert lit"(?m)$" == ""  # XXX \n
-  doAssert lit"弢" == ""  # XXX support unicode
-  doAssert lit"(?<=\d)ab" == "b"
-  doAssert lit"(?<=\w)ab" == "b"
-  doAssert lit"(?<=\w+)ab" == "b"
-  doAssert lit"\dab2" == "b"
-  doAssert lit"\d+ab2" == "b"
-  doAssert lit"\wab2" == ""
+  doAssert delim"abc" == "c"
+  doAssert delim"abcab" == "c"
+  doAssert delim"abc\wxyz" == "c"
+  doAssert delim"(abc)+" == ""
+  doAssert delim"(abc)+xyz" == "z"
+  doAssert delim"(abc)*" == ""
+  doAssert delim"(abc)*xyz" == "z"
+  doAssert delim"(a|b)" == ""
+  doAssert delim"(a+|b)" == ""
+  doAssert delim"(a+|b+)" == ""
+  doAssert delim"((abc)|(xyz))" == ""
+  doAssert delim"((abc)+|(xyz)+)" == ""
+  doAssert delim"((abc)*|(xyz)*)" == ""
+  doAssert delim"a?" == ""
+  doAssert delim"a?b" == "b"
+  doAssert delim"a" == "a"
+  doAssert delim"(a|b)xyz" == "z"
+  doAssert delim"(a|bc)xyz" == "z"
+  doAssert delim"(ab|c)xyz" == "z"
+  doAssert delim"a+b" == "b"
+  doAssert delim"a*b" == "b"
+  doAssert delim"b+b" == ""
+  doAssert delim"b*b" == ""
+  doAssert delim"\d+x" == "x"
+  doAssert delim"\d*x" == "x"
+  doAssert delim"\d?x" == "x"
+  doAssert delim"\w+x" == ""
+  doAssert delim"\w*x" == ""
+  doAssert delim"\w?x" == ""
+  doAssert delim"(\w\d)*abc" == ""
+  doAssert delim"(\w\d)+abc" == ""
+  doAssert delim"(\w\d)?abc" == ""
+  doAssert delim"z(x|y)+abc" == "z"
+  doAssert delim"((a|b)c*d?(ef)*\w\d\b@)+" == ""
+  doAssert delim"((a|b)c*d?(ef)*\w\d\b@)+&%" == "%"
+  doAssert delim"((a|b)c*d?(ef)*\w\d\b)+@&%" == "%"
+  doAssert delim"((a|b)c*d?(ef)*\w\d\bx)+" == ""
+  doAssert delim"((a|b)c*d?(ef)*\w\d\bx)+yz" == ""
+  doAssert delim"((a|b)c*d?(ef)*\w\d\b)+xyz" == ""
+  doAssert delim"^a?" == ""
+  doAssert delim"a?$" == ""
+  doAssert delim"(?m)^" == ""  # XXX \n
+  doAssert delim"(?m)$" == ""  # XXX \n
+  doAssert delim"弢" == "弢"
+  doAssert delim"(?<=\d)ab" == "b"
+  doAssert delim"(?<=\w)ab" == "b"
+  doAssert delim"(?<=\w+)ab" == "b"
+  doAssert delim"\dab2" == "b"
+  doAssert delim"\d+ab2" == "b"
+  doAssert delim"\wab2" == ""
 
-  doAssert r"abc".prefix.toString == r"ba".toNfa.toString
-  doAssert r"abcab".prefix.toString == r"ba".toNfa.toString
-  doAssert r"abc\wxyz".prefix.toString == r"ba".toNfa.toString
-  doAssert r"abccc".prefix.toString == r"ba".toNfa.toString
+  doAssert lits"a" == ""
+  doAssert lits"ab" == "ab"
+  doAssert lits"abc" == "abc"
+  doAssert lits"abcab" == "abcab"
+  doAssert lits"abc\wxyz" == "abc"
+  doAssert lits"(abc)+" == ""
+  doAssert lits"(abc)+xyz" == "xyz"
+  doAssert lits"(abc)*" == ""
+  doAssert lits"(abc)*xyz" == "xyz"
+  doAssert lits"(a|b)" == ""
+  doAssert lits"(a+|b)" == ""
+  doAssert lits"(a+|b+)" == ""
+  doAssert lits"((abc)|(xyz))" == ""
+  doAssert lits"((abc)+|(xyz)+)" == ""
+  doAssert lits"((abc)*|(xyz)*)" == ""
+  doAssert lits"a?" == ""
+  doAssert lits"a?b" == ""
+  doAssert lits"a?bc" == "bc"
+  doAssert lits"(a|b)xyz" == "xyz"
+  doAssert lits"(a|bc)xyz" == "xyz"
+  doAssert lits"(ab|c)xyz" == "xyz"
+  doAssert lits"a+b" == ""
+  doAssert lits"a+bc" == "bc"
+  doAssert lits"a*b" == ""
+  doAssert lits"a*bc" == "bc"
+  doAssert lits"b+b" == ""
+  doAssert lits"b*b" == ""
+  doAssert lits"\d+x" == ""
+  doAssert lits"\d+xy" == "xy"
+  doAssert lits"\d*x" == ""
+  doAssert lits"\d*xy" == "xy"
+  doAssert lits"\d?x" == ""
+  doAssert lits"\d?xy" == "xy"
+  doAssert lits"\w+x" == ""
+  doAssert lits"\w*x" == ""
+  doAssert lits"\w?x" == ""
+  doAssert lits"(\w\d)*abc" == ""
+  doAssert lits"(\w\d)+abc" == ""
+  doAssert lits"(\w\d)?abc" == ""
+  doAssert lits"z(x|y)+abc" == ""
+  doAssert lits"xyz(x|y)+abc" == "xyz"
+  doAssert lits"((a|b)c*d?(ef)*\w\d\b@)+" == ""
+  doAssert lits"((a|b)c*d?(ef)*\w\d\b@)+&%" == "&%"
+  doAssert lits"((a|b)c*d?(ef)*\w\d\b)+@&%" == "@&%"
+  doAssert lits"((a|b)c*d?(ef)*\w\d\bx)+" == ""
+  doAssert lits"((a|b)c*d?(ef)*\w\d\bx)+yz" == ""
+  doAssert lits"((a|b)c*d?(ef)*\w\d\b)+xyz" == ""
+  doAssert lits"^a?" == ""
+  doAssert lits"a?$" == ""
+  doAssert lits"(?m)^" == ""  # XXX \n
+  doAssert lits"(?m)$" == ""  # XXX \n
+  doAssert lits"弢" == "弢"
+  doAssert lits"(?<=\d)ab" == "ab"
+  doAssert lits"(?<=\w)ab" == "ab"
+  doAssert lits"(?<=\w+)ab" == "ab"
+  doAssert lits"\dab2" == "ab2"
+  doAssert lits"\d+ab2" == "ab2"
+  doAssert lits"\wab2" == ""
+
+  block:
+    let skipChars = {'(', ')', '+', '?', '*', '[', ']', '\\'}
+    var i = 0
+    for cp in 0 .. 127:
+      if cp.char in skipChars:
+        continue
+      doAssert lits(r"" & cp.char) == ""
+      inc i
+    doAssert i == 128-skipChars.len
+    doAssert lits(128.Rune.toUtf8).len == 2
+
+  doAssert r"abc".prefix.toString == r"".toNfa.toString
+  doAssert r"\dabc".prefix.toString == r"\d".toNfa.toString
+  doAssert r"abcab".prefix.toString == r"".toNfa.toString
+  doAssert r"\dabcab".prefix.toString == r"\d".toNfa.toString
+  doAssert r"abc\wxyz".prefix.toString == r"".toNfa.toString
+  doAssert r"\dabc\wxyz".prefix.toString == r"\d".toNfa.toString
+  doAssert r"abccc".prefix.toString == r"".toNfa.toString
+  doAssert r"\dabccc".prefix.toString == r"\d".toNfa.toString
   doAssert r"\w@".prefix.toString == r"\w".toNfa.toString
-  doAssert r"\w@&%".prefix.toString == r"&@\w".toNfa.toString
-  doAssert r"\w\d@&%".prefix.toString == r"&@\d\w".toNfa.toString
+  doAssert r"\w@&%".prefix.toString == r"\w".toNfa.toString
+  doAssert r"\w\d@&%".prefix.toString == r"\d\w".toNfa.toString
 
-  doAssert r"(a|b)xyz".prefix.toString == r"yx(a|b)".toNfa.toString
-  doAssert r"(a|ab)\w@&%".prefix.toString == r"&@\w(a|ba)".toNfa.toString
-  doAssert r"(a|ab)\w@&%".prefix.toString ==
-    "[#, [&, [@, [w, [a, eoe], [b, [a, eoe]]]]]]"
+  doAssert r"(a|b)xyz".prefix.toString == r"(a|b)".toNfa.toString
+  doAssert r"(a|ab)\w@&%".prefix.toString == r"\w(a|ba)".toNfa.toString
   doAssert r"a?b".prefix.toString == r"a?".toNfa.toString
   doAssert r"".prefix.s.len == 0
   doAssert r"a?".prefix.s.len == 0

--- a/src/regex/nfafindall.nim
+++ b/src/regex/nfafindall.nim
@@ -228,6 +228,8 @@ func findSomeOptImpl*(
   doAssert opt.nfa.s.len > 0
   initMaybeImpl(ms, regexSize)
   ms.clear()
+  let hasLits = opt.lits.len > 0
+  let step = max(1, opt.lits.len)
   var limit = start.int
   var i = start.int
   var i2 = -1
@@ -235,7 +237,10 @@ func findSomeOptImpl*(
     doAssert i > i2; i2 = i
     #debugEcho "lit=", opt.lit
     #debugEcho "i=", i
-    let litIdx = text.find(opt.lit.char, i)
+    let litIdx = if hasLits:
+      text.find(opt.lits, i)
+    else:
+      text.find(opt.lit.char, i)
     if litIdx == -1:
       return -1
     #debugEcho "litIdx=", litIdx
@@ -244,7 +249,7 @@ func findSomeOptImpl*(
     i = reversedMatchImpl(smA, smB, text, opt.nfa, look, i, limit)
     if i == -1:
       #debugEcho "not.Match=", i
-      i = litIdx+1
+      i = litIdx+step
     else:
       doAssert i <= litIdx
       #debugEcho "bounds.a=", i

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -273,6 +273,7 @@ func findSomeOptImpl*(
   initMaybeImpl(ms, regexSize, groupsLen)
   ms.clear()
   let hasLits = opt.lits.len > 0
+  let step = max(1, opt.lits.len)
   var limit = start.int
   var i = start.int
   var i2 = -1
@@ -292,7 +293,7 @@ func findSomeOptImpl*(
     i = reversedMatchImpl(smA, smB, text, opt.nfa, look, groupsLen, i, limit)
     if i == -1:
       #debugEcho "not.Match=", i
-      i = litIdx+1
+      i = litIdx+step
     else:
       doAssert i <= litIdx
       #debugEcho "bounds.a=", i

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -272,6 +272,7 @@ func findSomeOptImpl*(
   doAssert opt.nfa.s.len > 0
   initMaybeImpl(ms, regexSize, groupsLen)
   ms.clear()
+  let hasLits = opt.lits.len > 0
   var limit = start.int
   var i = start.int
   var i2 = -1
@@ -279,7 +280,10 @@ func findSomeOptImpl*(
     doAssert i > i2; i2 = i
     #debugEcho "lit=", opt.lit
     #debugEcho "i=", i
-    let litIdx = text.find(opt.lit.char, i)
+    let litIdx = if hasLits:
+      text.find(opt.lits, i)
+    else:
+      text.find(opt.lit.char, i)
     if litIdx == -1:
       return -1
     #debugEcho "litIdx=", litIdx

--- a/src/regex/parser.nim
+++ b/src/regex/parser.nim
@@ -227,7 +227,7 @@ func parseUnicodeName(sc: Scanner[Rune]): Node =
 
 func parseEscapedSeq(sc: Scanner[Rune]): Node =
   ## Parse a escaped sequence
-  case sc.curr
+  case sc.peek
   of "u".toRune:
     discard sc.next()
     result = parseUnicodeLit(sc, 4)
@@ -250,6 +250,9 @@ func parseEscapedSeq(sc: Scanner[Rune]): Node =
     discard sc.next()
     result = parseUnicodeName(sc)
     result.kind = reNotUCC
+  of invalidRune:
+    let startPos = sc.pos
+    prettyCheck(false, "Nothing to escape")
   else:
     result = next(sc).toEscapedNode
 

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2771,6 +2771,47 @@ test "misc4":
   check findAllBounds(r"1a1a1", re2"(?<=\d)a\d") == @[1 .. 2, 3 .. 4]
   check findAllBounds(r"a1a1", re2"(?<=\d)a\d") == @[2 .. 3]
 
+test "misc5":
+  check findAllStr(r"x 弢 x 弢", re2"弢") == @["弢", "弢"]
+  check findAllStr(r"x Ⓐ x Ⓐ", re2"Ⓐ") == @["Ⓐ", "Ⓐ"]
+  check findAllStr(r"x Ϊ x Ϊ", re2"Ϊ") == @["Ϊ", "Ϊ"]
+  check findAllStr(r"x ΪⒶ弢 x", re2"ΪⒶ弢") == @["ΪⒶ弢"]
+  check findAllStr(r"x ΪⒶ弢 x ΪⒶ弢", re2"ΪⒶ弢") ==
+    @["ΪⒶ弢", "ΪⒶ弢"]
+  check findAllStr(r"ΪⒶ弢 x ΪⒶ弢 x ΪⒶ弢", re2"ΪⒶ弢") ==
+    @["ΪⒶ弢", "ΪⒶ弢", "ΪⒶ弢"]
+  check findAllStr(r"1弢2弢", re2"\d弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢弢2弢", re2"\d弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢Ⓐ2弢", re2"\d弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢Ϊ2弢", re2"\d弢") == @["1弢", "2弢"]
+  check findAllStr(r"1Ⓐ弢Ⓐ弢", re2"\dⒶ弢") == @["1Ⓐ弢"]
+  check findAllStr(r"1Ⓐ弢2Ⓐ弢", re2"\dⒶ弢") == @["1Ⓐ弢", "2Ⓐ弢"]
+  check findAllStr(r"1Ⓐ弢Ⓐ弢2Ⓐ弢", re2"\dⒶ弢") == @["1Ⓐ弢", "2Ⓐ弢"]
+  check findAllStr(r"1Ϊ弢Ϊ弢", re2"\dΪ弢") == @["1Ϊ弢"]
+  check findAllStr(r"1Ϊ弢2Ϊ弢", re2"\dΪ弢") == @["1Ϊ弢", "2Ϊ弢"]
+  check findAllStr(r"1Ϊ弢Ϊ弢2Ϊ弢", re2"\dΪ弢") == @["1Ϊ弢", "2Ϊ弢"]
+  check findAllStr(r"1ΪⒶΪⒶ", re2"\dΪⒶ") == @["1ΪⒶ"]
+  check findAllStr(r"1ΪⒶ2ΪⒶ", re2"\dΪⒶ") == @["1ΪⒶ", "2ΪⒶ"]
+  check findAllStr(r"1ΪⒶΪⒶ2ΪⒶ", re2"\dΪⒶ") == @["1ΪⒶ", "2ΪⒶ"]
+  check findAllStr(r"1ⒶⒶ", re2"\dⒶ") == @["1Ⓐ"]
+  check findAllStr(r"1Ⓐ2Ⓐ", re2"\dⒶ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1ⒶⒶ2Ⓐ", re2"\dⒶ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1ΪΪ", re2"\dΪ") == @["1Ϊ"]
+  check findAllStr(r"1Ϊ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1ΪΪ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1弢2弢", re2".弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢弢2弢", re2".弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢Ⓐ2弢", re2".弢") == @["1弢", "2弢"]
+  check findAllStr(r"1弢Ϊ2弢", re2".弢") == @["1弢", "2弢"]
+  check findAllStr(r"1Ⓐ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1ⒶⒶ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1Ⓐ弢2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1ⒶΪ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1Ϊ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1ΪΪ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1Ϊ弢2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1ΪⒶ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
+
 test "fix#83":
   block:
     let pattern = "^src/(?:[^\\/]*(?:\\/|$))*[^/]*\\.nim$"

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2799,18 +2799,10 @@ test "misc5":
   check findAllStr(r"1ΪΪ", re2"\dΪ") == @["1Ϊ"]
   check findAllStr(r"1Ϊ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
   check findAllStr(r"1ΪΪ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
-  check findAllStr(r"1弢2弢", re2".弢") == @["1弢", "2弢"]
-  check findAllStr(r"1弢弢2弢", re2".弢") == @["1弢", "2弢"]
-  check findAllStr(r"1弢Ⓐ2弢", re2".弢") == @["1弢", "2弢"]
-  check findAllStr(r"1弢Ϊ2弢", re2".弢") == @["1弢", "2弢"]
-  check findAllStr(r"1Ⓐ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
-  check findAllStr(r"1ⒶⒶ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
-  check findAllStr(r"1Ⓐ弢2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
-  check findAllStr(r"1ⒶΪ2Ⓐ", re2".Ⓐ") == @["1Ⓐ", "2Ⓐ"]
-  check findAllStr(r"1Ϊ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
-  check findAllStr(r"1ΪΪ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
-  check findAllStr(r"1Ϊ弢2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
-  check findAllStr(r"1ΪⒶ2Ϊ", re2".Ϊ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1Ⓐ弢2Ⓐ", re2"\dⒶ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1ⒶΪ2Ⓐ", re2"\dⒶ") == @["1Ⓐ", "2Ⓐ"]
+  check findAllStr(r"1Ϊ弢2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"1ΪⒶ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
 
 test "fix#83":
   block:

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2810,6 +2810,16 @@ test "misc5":
   check findAllStr(r"abcde1", re2"abc?de\d") == @["abcde1"]
   check findAllStr(r"abde1 abde2 abcde3", re2"abc?de\d") ==
     @["abde1", "abde2", "abcde3"]
+  check findAllStr(r"1abc2abc3", re2"\wabc\w") == @["1abc2"]
+  check findAllStr(r"1abcabc", re2"\wabc") == @["1abc"]
+  check findAllStr(r"abcabc", re2"abc\w") == @["abca"]
+  check findAllStr(r"1ΪⒶ弢2ΪⒶ弢3", re2"\wΪⒶ弢\w") == @["1ΪⒶ弢2"]
+  check findAllStr(r"1Ϊ弢2Ϊ弢3", re2"\wΪ弢\w") == @["1Ϊ弢2"]
+  check findAllStr(r"1Ϊ2Ϊ3", re2"\wΪ\w") == @["1Ϊ2"]
+  check findAllStr(r"1Ⓐ2Ⓐ3", re2"\wⒶ\w") == @["1Ⓐ2"]
+  check findAllStr(r"1弢2弢3", re2"\w弢\w") == @["1弢2"]
+  check findAllStr(r"1ΪⒶ弢ΪⒶ弢", re2"\wΪⒶ弢") == @["1ΪⒶ弢"]
+  check findAllStr(r"ΪⒶ弢ΪⒶ弢", re2"ΪⒶ弢\w") == @["ΪⒶ弢Ϊ"]
 
 test "misc6_sanitycheck":
   block:

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2813,7 +2813,7 @@ test "misc5":
   check findAllStr(r"1abc2abc3", re2"\wabc\w") == @["1abc2"]
   check findAllStr(r"1abc2abc3abc4", re2"\wabc\w") == @["1abc2", "3abc4"]
   check findAllStr(r"1abcabc", re2"\wabc") == @["1abc"]
-  check findAllStr(r"abcabc", re2"abc\w") == @["abca"]
+  check findAllStr(r"abcabcx", re2"abc\w") == @["abca"]
   check findAllStr(r"abcabcabcd", re2"abc\w") == @["abca", "abcd"]
   check findAllStr(r"aaab", re2"a\w") == @["aa", "ab"]
   check findAllStr(r"1a2a3a4", re2"\wa\w") == @["1a2", "3a4"]
@@ -2823,7 +2823,7 @@ test "misc5":
   check findAllStr(r"1Ⓐ2Ⓐ3", re2"\wⒶ\w") == @["1Ⓐ2"]
   check findAllStr(r"1弢2弢3", re2"\w弢\w") == @["1弢2"]
   check findAllStr(r"1ΪⒶ弢ΪⒶ弢", re2"\wΪⒶ弢") == @["1ΪⒶ弢"]
-  check findAllStr(r"ΪⒶ弢ΪⒶ弢", re2"ΪⒶ弢\w") == @["ΪⒶ弢Ϊ"]
+  check findAllStr(r"ΪⒶ弢ΪⒶ弢x", re2"ΪⒶ弢\w") == @["ΪⒶ弢Ϊ"]
   check findAllStr(r"弢弢弢Ⓐ", re2"弢\w") == @["弢弢", "弢Ⓐ"]
   check findAllStr(r"1弢2弢3弢4", re2"\w弢\w") == @["1弢2", "3弢4"]
 

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -567,6 +567,7 @@ test "trepetition_cycle":
   check "aaabbbaaa".isMatch(re2"((a*|b*))*")
   check raises(r"a*****")
   check raises(r"a*{,}")
+  check raises(r"\")
   check "aaa".isMatch(re2"(a?)*")
   check "aaaa".isMatch(re2"((a)*(a)*)*")
   # Same as PCRE "^(a*)*?$"
@@ -2803,6 +2804,26 @@ test "misc5":
   check findAllStr(r"1ⒶΪ2Ⓐ", re2"\dⒶ") == @["1Ⓐ", "2Ⓐ"]
   check findAllStr(r"1Ϊ弢2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
   check findAllStr(r"1ΪⒶ2Ϊ", re2"\dΪ") == @["1Ϊ", "2Ϊ"]
+  check findAllStr(r"abde", re2"abc?de") == @["abde"]
+  check findAllStr(r"abcde", re2"abc?de") == @["abcde"]
+  check findAllStr(r"abde1", re2"abc?de\d") == @["abde1"]
+  check findAllStr(r"abcde1", re2"abc?de\d") == @["abcde1"]
+  check findAllStr(r"abde1 abde2 abcde3", re2"abc?de\d") ==
+    @["abde1", "abde2", "abcde3"]
+
+test "misc6_sanitycheck":
+  block:
+    let skipChars = {
+      '(', ')', '+', '?', '*', '[',
+      ']', '\\', '.', '$', '^', '|'
+    }
+    var i = 0
+    for cp in 0 .. 127:
+      if cp.char in skipChars:
+        continue
+      doAssert findAllStr("弢", re2(r"" & cp.char)).len == 0
+      inc i
+    check i == 128-skipChars.len
 
 test "fix#83":
   block:

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2821,7 +2821,7 @@ test "misc6_sanitycheck":
     for cp in 0 .. 127:
       if cp.char in skipChars:
         continue
-      doAssert findAllStr("弢", re2(r"" & cp.char)).len == 0
+      check findAllStr("弢", re2(r"" & cp.char)).len == 0
       inc i
     check i == 128-skipChars.len
 

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -2811,8 +2811,12 @@ test "misc5":
   check findAllStr(r"abde1 abde2 abcde3", re2"abc?de\d") ==
     @["abde1", "abde2", "abcde3"]
   check findAllStr(r"1abc2abc3", re2"\wabc\w") == @["1abc2"]
+  check findAllStr(r"1abc2abc3abc4", re2"\wabc\w") == @["1abc2", "3abc4"]
   check findAllStr(r"1abcabc", re2"\wabc") == @["1abc"]
   check findAllStr(r"abcabc", re2"abc\w") == @["abca"]
+  check findAllStr(r"abcabcabcd", re2"abc\w") == @["abca", "abcd"]
+  check findAllStr(r"aaab", re2"a\w") == @["aa", "ab"]
+  check findAllStr(r"1a2a3a4", re2"\wa\w") == @["1a2", "3a4"]
   check findAllStr(r"1ΪⒶ弢2ΪⒶ弢3", re2"\wΪⒶ弢\w") == @["1ΪⒶ弢2"]
   check findAllStr(r"1Ϊ弢2Ϊ弢3", re2"\wΪ弢\w") == @["1Ϊ弢2"]
   check findAllStr(r"1Ϊ2Ϊ3", re2"\wΪ\w") == @["1Ϊ2"]
@@ -2820,6 +2824,8 @@ test "misc5":
   check findAllStr(r"1弢2弢3", re2"\w弢\w") == @["1弢2"]
   check findAllStr(r"1ΪⒶ弢ΪⒶ弢", re2"\wΪⒶ弢") == @["1ΪⒶ弢"]
   check findAllStr(r"ΪⒶ弢ΪⒶ弢", re2"ΪⒶ弢\w") == @["ΪⒶ弢Ϊ"]
+  check findAllStr(r"弢弢弢Ⓐ", re2"弢\w") == @["弢弢", "弢Ⓐ"]
+  check findAllStr(r"1弢2弢3弢4", re2"\w弢\w") == @["1弢2", "3弢4"]
 
 test "misc6_sanitycheck":
   block:


### PR DESCRIPTION
This reuses the lits opt to find the lit delimiter, then grabs the surrounding lits, and tries to find the literal sub-string. It should usually be faster when `memmem` is supported.

I also added support for unicode lit delimiters.

Added some benchs where it's ~6x faster than before, and 3x faster than PCRE.

I think the idea is good, but the code can be simpler.