### PR TITLE
Verify input is utf-8

### DIFF
--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -1,3 +1,4 @@
+import ./common
 import ./parser
 import ./exptransformation
 import ./types
@@ -8,6 +9,8 @@ when defined(regexDotDir):
   import ./dotgraph
 
 func reImpl*(s: string): Regex {.inline.} =
+  if verifyUtf8(s) != -1:
+    raise newException(RegexError, "Invalid utf-8 regex")
   var groups: GroupsCapture
   let rpn = s
     .parse

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1126,7 +1126,7 @@ test "tstarts_with":
   check(not "abc".startsWith(re"bc"))
   check startsWith("弢ⒶΪ", re"弢Ⓐ")
   check startsWith("弢", re("\xF0\xAF\xA2\x94"))
-  check(not startsWith("弢", re("\xF0\xAF\xA2")))
+  #check(not startsWith("弢", re("\xF0\xAF\xA2")))
   check "abc".startsWith(re"\w")
   check(not "abc".startsWith(re"\d"))
   check "abc".startsWith(re"(a|b)")
@@ -1142,7 +1142,7 @@ test "tends_with":
   check(not "abc".endsWith(re"ab"))
   check endsWith("弢ⒶΪ", re"ⒶΪ")
   check endsWith("弢", re("\xF0\xAF\xA2\x94"))
-  check(not endsWith("弢", re("\xAF\xA2\x94")))
+  #check(not endsWith("弢", re("\xAF\xA2\x94")))
   check "abc".endsWith(re"(b|c)")
   check "ab".endsWith(re"(b|c)")
   check(not "a".endsWith(re"(b|c)"))
@@ -2475,7 +2475,7 @@ test "escapeRe":
   check match("$", re(escapeRe"$"))
   block:
     var s = ""
-    for c in 0 .. 255:
+    for c in 0 .. 127:
       s.add c.char
     discard re(escapeRe(s))
 

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3027,11 +3027,16 @@ test "tlookaround_captures":
   check match("aaab", re2"(\w)(\w+)|\w+(?<=^(\w)(\w)(\w+))b", m) and
     m.captures == @[0 .. 0, 1 .. 3, nonCapture, nonCapture, nonCapture]
 
+when (NimMajor, NimMinor) >= (2, 0):
+  type MyAssertionDefect = ref AssertionDefect
+else:
+  type MyAssertionDefect = ref AssertionError
+
 template raisesInvalidUtf8(exp: untyped): untyped =
   try:
     discard exp
     check false
-  except AssertionDefect:
+  except MyAssertionDefect:
     check "Invalid utf-8 input" in getCurrentExceptionMsg()
 
 test "tverifyutf8":


### PR DESCRIPTION
Add utf-8 validation to regex and input strings. For regex it's always on. For input text only verify on debug mode.

The behavior on invalid utf-8 input for release/danger mode is still undefined. Not ideal but better than nothing.