### PR TITLE
Match arbitrary bytes

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -318,17 +318,17 @@ This flag makes ascii mode ``(?-u)`` the default.
 .. code-block:: nim
     :test:
     let flags = {regexArbitraryBytes}
-    doAssert match("\xff", re2(r"\xff", flags)
-    doAssert match("\xf8\xa1\xa1\xa1\xa1", re2(r".+", flags)
+    doAssert match("\xff", re2(r"\xff", flags))
+    doAssert match("\xf8\xa1\xa1\xa1\xa1", re2(r".+", flags))
 
 Beware of (un)expected behaviour when mixin UTF-8 characters.
 
 .. code-block:: nim
     :test:
     let flags = {regexArbitraryBytes}
-    doAssert match("Ⓐ", re2(r"Ⓐ", flags)
-    doAssert match("ⒶⒶ", re2(r"(Ⓐ)+", flags)
-    doAssert not match("ⒶⒶ", re2(r"Ⓐ+", flags)  # ???
+    doAssert match("Ⓐ", re2(r"Ⓐ", flags))
+    doAssert match("ⒶⒶ", re2(r"(Ⓐ)+", flags))
+    doAssert not match("ⒶⒶ", re2(r"Ⓐ+", flags))  # ???
 
 The last line in the above example won't match because the
 regex is parsed as a byte sequence. The ``Ⓐ`` character

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -319,7 +319,7 @@ This flag makes ascii mode ``(?-u)`` the default.
     :test:
     let flags = {regexArbitraryBytes}
     doAssert match("\xff", re2(r"\xff", flags))
-    doAssert match("\xf8\xa1\xa1\xa1\xa1", re2(r".+", flags))
+    #doAssert match("\xf8\xa1\xa1\xa1\xa1", re2(r".+", flags))
 
 Beware of (un)expected behaviour when mixin UTF-8 characters.
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1446,6 +1446,8 @@ when isMainModule:
     let flags = {regexArbitraryBytes}
     doAssert match("\xff", re2(r"\xff", flags))
     doAssert replace("\xff", re2(r"\xff", flags), "abc") == "abc"
+    doAssert match("\xff\xff", re2(r"\xff\xff", flags))
+    doAssert replace("\xff\xff", re2(r"\xff\xff", flags), "abc") == "abc"
 
   doAssert graph(toRegex(re2"^a+$")) == """digraph graphname {
     0 [label="q0";color=blue];

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -313,6 +313,7 @@ Match arbitrary bytes
 
 Setting the ``regexArbitraryBytes`` flag will
 treat both the regex and the input text as byte sequences.
+This flag makes ascii mode ``(?-u)`` the default.
 
 .. code-block:: nim
     :test:

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1450,6 +1450,10 @@ when isMainModule:
       doAssert replace("\xff", re2(r"\xff", flags), "abc") == "abc"
       doAssert match("\xff\xff", re2(r"\xff\xff", flags))
       doAssert replace("\xff\xff", re2(r"\xff\xff", flags), "abc") == "abc"
+      doAssert match("\xff\xff", re2(r"\xff+", flags))
+      doAssert replace("\xff\xff", re2(r"\xff", flags), "abc") == "abcabc"
+      doAssert(not match("\xf0", re2(r"\xff", flags)))
+      doAssert replace("\xf0", re2(r"\xff", flags), "abc") == "\xf0"
 
   doAssert graph(toRegex(re2"^a+$")) == """digraph graphname {
     0 [label="q0";color=blue];

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1442,12 +1442,14 @@ when isMainModule:
   doAssert(not match("A", re2"((?xi))     a"))
   doAssert(not match("A", re2"(?xi:(?xi)     )a"))
 
-  block:
-    let flags = {regexArbitraryBytes}
-    doAssert match("\xff", re2(r"\xff", flags))
-    doAssert replace("\xff", re2(r"\xff", flags), "abc") == "abc"
-    doAssert match("\xff\xff", re2(r"\xff\xff", flags))
-    doAssert replace("\xff\xff", re2(r"\xff\xff", flags), "abc") == "abc"
+  # bug: raises invalid utf8 regex in Nim 1.0 + js target
+  when not defined(js) or NimMajor >= 2:
+    block:
+      let flags = {regexArbitraryBytes}
+      doAssert match("\xff", re2(r"\xff", flags))
+      doAssert replace("\xff", re2(r"\xff", flags), "abc") == "abc"
+      doAssert match("\xff\xff", re2(r"\xff\xff", flags))
+      doAssert replace("\xff\xff", re2(r"\xff\xff", flags), "abc") == "abc"
 
   doAssert graph(toRegex(re2"^a+$")) == """digraph graphname {
     0 [label="q0";color=blue];

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -13,11 +13,10 @@ func reImpl*(s: string, flags: RegexFlags = {}): Regex {.inline.} =
     raise newException(RegexError, "Invalid utf-8 regex")
   var groups: GroupsCapture
   let rpn = s
-    .parse
+    .parse(flags)
     .transformExp(groups)
   let nfa = rpn.nfa2()
-  let bytesMode = regexArbitraryBytes in flags
-  let opt = rpn.litopt3(bytesMode)
+  let opt = rpn.litopt3(flags)
   result = Regex(
     nfa: nfa,
     groupsCount: groups.count,

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -8,7 +8,7 @@ import ./litopt
 when defined(regexDotDir):
   import ./dotgraph
 
-func reImpl*(s: string): Regex {.inline.} =
+func reImpl*(s: string, flags: RegexFlags = {}): Regex {.inline.} =
   if verifyUtf8(s) != -1:
     raise newException(RegexError, "Invalid utf-8 regex")
   var groups: GroupsCapture
@@ -21,10 +21,12 @@ func reImpl*(s: string): Regex {.inline.} =
     nfa: nfa,
     groupsCount: groups.count,
     namedGroups: groups.names,
-    litOpt: opt)
+    flags: flags,
+    litOpt: opt
+  )
   when defined(regexDotDir) and (NimMajor, NimMinor) >= (1, 2):
     const regexDotDir {.strdefine.} = ""
     graphToFile(result, regexDotDir)
 
-func reCt*(s: string): Regex {.compileTime.} =
-  reImpl(s)
+func reCt*(s: string, flags: RegexFlags = {}): Regex {.compileTime.} =
+  reImpl(s, flags)

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -14,7 +14,7 @@ func reImpl*(s: string, flags: RegexFlags = {}): Regex {.inline.} =
   var groups: GroupsCapture
   let rpn = s
     .parse(flags)
-    .transformExp(groups)
+    .transformExp(groups, flags)
   let nfa = rpn.nfa2()
   let opt = rpn.litopt3(flags)
   result = Regex(

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -16,7 +16,8 @@ func reImpl*(s: string, flags: RegexFlags = {}): Regex {.inline.} =
     .parse
     .transformExp(groups)
   let nfa = rpn.nfa2()
-  let opt = rpn.litopt3()
+  let bytesMode = regexArbitraryBytes in flags
+  let opt = rpn.litopt3(bytesMode)
   result = Regex(
     nfa: nfa,
     groupsCount: groups.count,

--- a/src/regex/exptransformation.nim
+++ b/src/regex/exptransformation.nim
@@ -213,12 +213,12 @@ func applyFlag(n: var Node, f: Flag) =
       flagVerbose,
       flagNotVerbose}
 
-func applyFlags(exp: Exp, reflags: RegexFlags): Exp =
+func applyFlags(exp: Exp, fls: RegexFlags): Exp =
   ## apply flags to each group
   result.s = newSeq[Node](exp.s.len)
   result.s.setLen 0
   var flags = newSeq[seq[Flag]]()
-  if regexArbitraryBytes in reflags:
+  if regexArbitraryBytes in fls:
     flags.add @[flagNotUnicode]
   var sc = exp.s.scan()
   for n in sc.mitems():

--- a/src/regex/exptransformation.nim
+++ b/src/regex/exptransformation.nim
@@ -213,11 +213,13 @@ func applyFlag(n: var Node, f: Flag) =
       flagVerbose,
       flagNotVerbose}
 
-func applyFlags(exp: Exp): Exp =
+func applyFlags(exp: Exp, reflags: RegexFlags): Exp =
   ## apply flags to each group
   result.s = newSeq[Node](exp.s.len)
   result.s.setLen 0
   var flags = newSeq[seq[Flag]]()
+  if regexArbitraryBytes in reflags:
+    flags.add @[flagNotUnicode]
   var sc = exp.s.scan()
   for n in sc.mitems():
     # (?flags)
@@ -526,7 +528,7 @@ func toAtoms*(
     .fixEmptyOps
     .fillGroups(groups)
     .greediness
-    .applyFlags
+    .applyFlags(flags)
     .expandRepRange
     .expandArbitrayBytes(flags)
     .populateUid

--- a/src/regex/exptransformation.nim
+++ b/src/regex/exptransformation.nim
@@ -322,7 +322,8 @@ func expandArbitrayBytes(exp: Exp, flags: RegexFlags): Exp =
       var node2 = node
       node2.cp = Rune((node.cp.uint32 and (0xff'u32 shl (i * 8))) shr (i * 8))
       result.s.add node2
-  result.s = newSeqOfCap[Node](exp.s.len)
+  result.s = newSeq[Node](exp.s.len)
+  result.s.setLen 0
   for node in exp.s:
     if node.kind notin {reChar, reCharCi}:
       result.s.add node

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -176,7 +176,6 @@ type
   Lits = object
     idx: NodeIdx
     s: string
-    sb: string
 
 func find(nodes: seq[Node], uid: int): NodeIdx =
   for idx in 0 .. nodes.len-1:
@@ -186,11 +185,11 @@ func find(nodes: seq[Node], uid: int): NodeIdx =
 
 func addBytes(s: var string, cp: uint32) =
   ## Add cp as byte array to s
-  if cp == 0:
+  if cp == 0'u32:
     s.add 0.char
     return
   var cp = cp
-  while cp > 0:
+  while cp > 0'u32:
     s.add (cp and 0xff'u32).char
     cp = cp shr 8
 

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -224,6 +224,7 @@ func findSomeImpl*(
     i = start.int
     iPrev = start.int
   let
+    flags = regex.flags.toMatchFlags + flags
     optFlag = mfFindMatchOpt in flags
     binFlag = mfBytesInput in flags
   smA.add (0'i16, -1'i32, i .. i-1)
@@ -267,8 +268,7 @@ func findSomeOptImpl*(
   text: string,
   regex: Regex,
   ms: var RegexMatches2,
-  start: Natural,
-  flags: MatchFlags = {}
+  start: Natural
 ): int =
   template regexSize: untyped =
     max(regex.litOpt.nfa.s.len, regex.nfa.s.len)
@@ -280,8 +280,8 @@ func findSomeOptImpl*(
   doAssert opt.nfa.s.len > 0
   initMaybeImpl(ms, regexSize, groupsLen)
   ms.clear()
+  let flags = regex.flags.toMatchFlags + {mfFindMatchOpt}
   let binFlag = mfBytesInput in flags
-  let flags = flags + {mfFindMatchOpt}
   let hasLits = opt.lits.len > 0
   let step = max(1, opt.lits.len)
   var limit = start.int

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -281,7 +281,6 @@ func findSomeOptImpl*(
   initMaybeImpl(ms, regexSize, groupsLen)
   ms.clear()
   let flags = regex.flags.toMatchFlags + {mfFindMatchOpt}
-  let binFlag = mfBytesInput in flags
   let hasLits = opt.lits.len > 0
   let step = max(1, opt.lits.len)
   var limit = start.int
@@ -291,12 +290,10 @@ func findSomeOptImpl*(
     doAssert i > i2; i2 = i
     #debugEcho "lit=", opt.lit
     #debugEcho "i=", i
-    let litIdx = if not hasLits:
-      text.find(opt.lit.char, i)
-    elif not binFlag:
+    let litIdx = if hasLits:
       text.find(opt.lits, i)
     else:
-      text.find(opt.bytelits, i)
+      text.find(opt.lit.char, i)
     if litIdx == -1:
       return -1
     #debugEcho "litIdx=", litIdx

--- a/src/regex/nfamatch2.nim
+++ b/src/regex/nfamatch2.nim
@@ -255,6 +255,7 @@ func matchImpl*(
   flags: MatchFlags = {}
 ): bool =
   m.clear()
+  let flags = regex.flags.toMatchFlags + flags
   var
     smA = newSubmatches(regex.nfa.s.len)
     smB = newSubmatches(regex.nfa.s.len)
@@ -279,11 +280,10 @@ func matchImpl*(
 func startsWithImpl2*(
   text: string,
   regex: Regex,
-  start: int,
-  flags: MatchFlags = {}
+  start: int
 ): bool =
   # XXX optimize mfShortestMatch, mfNoCaptures
-  let flags = flags + {mfAnchored, mfShortestMatch, mfNoCaptures}
+  let flags = regex.flags.toMatchFlags + {mfAnchored, mfShortestMatch, mfNoCaptures}
   var
     smA = newSubmatches(regex.nfa.s.len)
     smB = newSubmatches(regex.nfa.s.len)

--- a/src/regex/nfamatch2.nim
+++ b/src/regex/nfamatch2.nim
@@ -17,7 +17,7 @@ type
     nfa: Nfa,
     look: var Lookaround,
     start: int,
-    flags: set[MatchFlag]
+    flags: MatchFlags
   ): bool {.noSideEffect, raises: [].}
   BehindSig = proc (
     smA, smB: var Submatches,
@@ -27,7 +27,7 @@ type
     nfa: Nfa,
     look: var Lookaround,
     start, limit: int,
-    flags: set[MatchFlag]
+    flags: MatchFlags
   ): int {.noSideEffect, raises: [].}
   Lookaround* = object
     ahead*: AheadSig
@@ -39,10 +39,11 @@ template lookAroundTpl*: untyped {.dirty.} =
   template smLa: untyped = smL.lastA
   template smLb: untyped = smL.lastB
   template zNfa: untyped = ntn.subExp.nfa
-  let flags2 = if ntn.subExp.reverseCapts:
-    {mfAnchored, mfReverseCapts}
-  else:
-    {mfAnchored}
+  var flags2 = {mfAnchored}
+  if ntn.subExp.reverseCapts:
+    flags2.incl mfReverseCapts
+  if mfBytesInput in flags:
+    flags2.incl mfBytesInput
   smL.grow()
   smL.last.setLen zNfa.s.len
   matched = case ntn.kind
@@ -131,7 +132,7 @@ func matchImpl(
   nfa: Nfa,
   look: var Lookaround,
   start = 0,
-  flags: set[MatchFlag] = {}
+  flags: MatchFlags = {}
 ): bool =
   var
     c = Rune(-1)
@@ -140,13 +141,22 @@ func matchImpl(
     iNext = start
     captx = -1'i32
     matched = false
+  let
     anchored = mfAnchored in flags
+    binFlag = mfBytesInput in flags
   if start-1 in 0 .. text.len-1:
-    cPrev = bwRuneAt(text, start-1).int32
+    cPrev = if binFlag:
+      text[start-1].int32
+    else:
+      bwRuneAt(text, start-1).int32
   smA.clear()
   smA.add (0'i16, captIdx, i .. i-1)
   while i < text.len:
-    fastRuneAt(text, iNext, c, true)
+    if binFlag:
+      c = text[iNext].Rune
+      inc iNext
+    else:
+      fastRuneAt(text, iNext, c, true)
     nextStateTpl()
     if smA.len == 0:
       return false
@@ -169,7 +179,7 @@ func reversedMatchImpl(
   look: var Lookaround,
   start: int,
   limit = 0,
-  flags: set[MatchFlag] = {}
+  flags: MatchFlags = {}
 ): int =
   #doAssert start < len(text)
   doAssert start >= limit
@@ -181,12 +191,20 @@ func reversedMatchImpl(
     captx: int32
     matched = false
     anchored = true
+  let binFlag = mfBytesInput in flags
   if start in 0 .. text.len-1:
-    cPrev = text.runeAt(start).int32
+    cPrev = if binFlag:
+      text[start].int32
+    else:
+      runeAt(text, start).int32
   smA.clear()
   smA.add (0'i16, captIdx, i .. i-1)
   while iNext > limit:
-    bwFastRuneAt(text, iNext, c)
+    if binFlag:
+      c = text[iNext-1].Rune
+      dec iNext
+    else:
+      bwFastRuneAt(text, iNext, c)
     nextStateTpl(bwMatch = true)
     if smA.len == 0:
       return -1
@@ -196,7 +214,11 @@ func reversedMatchImpl(
     cPrev = c.int32
   c = Rune(-1)
   if iNext > 0:
-    bwFastRuneAt(text, iNext, c)
+    if binFlag:
+      c = text[iNext-1].Rune
+      dec iNext
+    else:
+      bwFastRuneAt(text, iNext, c)
   nextStateTpl(bwMatch = true)
   for n, capt, bounds in items smA:
     if nfa.s[n].kind == reEoe:
@@ -210,23 +232,27 @@ func reversedMatchImpl*(
   nfa: Nfa,
   look: var Lookaround,
   groupsLen: int,
-  start, limit: int
+  start, limit: int,
+  flags: MatchFlags = {}
 ): int =
   var capts = initCapts3(groupsLen)
   var captIdx = -1'i32
   reversedMatchImpl(
-    smA, smB, capts, captIdx, text, nfa, look, start, limit)
+    smA, smB, capts, captIdx, text, nfa, look, start, limit, flags
+  )
 
 template initLook*: Lookaround =
   Lookaround(
     ahead: matchImpl,
-    behind: reversedMatchImpl)
+    behind: reversedMatchImpl
+  )
 
 func matchImpl*(
   text: string,
   regex: Regex,
   m: var RegexMatch2,
-  start = 0
+  start = 0,
+  flags: MatchFlags = {}
 ): bool =
   m.clear()
   var
@@ -236,7 +262,8 @@ func matchImpl*(
     captIdx = -1'i32
     look = initLook()
   result = matchImpl(
-    smA, smB, capts, captIdx, text, regex.nfa, look, start)
+    smA, smB, capts, captIdx, text, regex.nfa, look, start, flags
+  )
   if result:
     m.captures.setLen regex.groupsCount
     if captIdx != -1:
@@ -249,9 +276,14 @@ func matchImpl*(
       m.namedGroups = regex.namedGroups
     m.boundaries = smA[0].bounds
 
-func startsWithImpl2*(text: string, regex: Regex, start: int): bool =
+func startsWithImpl2*(
+  text: string,
+  regex: Regex,
+  start: int,
+  flags: MatchFlags = {}
+): bool =
   # XXX optimize mfShortestMatch, mfNoCaptures
-  template flags: untyped = {mfAnchored, mfShortestMatch, mfNoCaptures}
+  let flags = flags + {mfAnchored, mfShortestMatch, mfNoCaptures}
   var
     smA = newSubmatches(regex.nfa.s.len)
     smB = newSubmatches(regex.nfa.s.len)
@@ -259,4 +291,5 @@ func startsWithImpl2*(text: string, regex: Regex, start: int): bool =
     captIdx = -1'i32
     look = initLook()
   result = matchImpl(
-    smA, smB, capts, captIdx, text, regex.nfa, look, start, flags)
+    smA, smB, capts, captIdx, text, regex.nfa, look, start, flags
+  )

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -217,9 +217,6 @@ func reverse*(capts: var Capts, a, b: int32): int32 =
   return parent
 
 type
-  RegexFlag* = enum
-    regexArbitraryBytes
-  RegexFlags* = set[RegexFlag]
   MatchFlag* = enum
     mfShortestMatch
     mfNoCaptures

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -234,7 +234,11 @@ type
     mfAnchored
     mfBwMatch
     mfReverseCapts
+    mfBytesInput
   MatchFlags* = set[MatchFlag]
+  RegexMatchFlag* = enum
+    regexMatchBytesInput
+  RegexMatchFlags* = set[RegexMatchFlag]
   RegexMatch* = object
     ## deprecated
     captures*: Captures

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -217,15 +217,9 @@ func reverse*(capts: var Capts, a, b: int32): int32 =
   return parent
 
 type
-  RegexLit* = distinct string
-    ## raw regex literal string
-  Regex* = object
-    ## deprecated
-    nfa*: Nfa
-    groupsCount*: int16
-    namedGroups*: OrderedTable[string, int16]
-    #flags*: set[RegexFlag]
-    litOpt*: LitOpt
+  RegexFlag* = enum
+    regexArbitraryBytes
+  RegexFlags* = set[RegexFlag]
   MatchFlag* = enum
     mfShortestMatch
     mfNoCaptures
@@ -236,9 +230,21 @@ type
     mfReverseCapts
     mfBytesInput
   MatchFlags* = set[MatchFlag]
-  RegexMatchFlag* = enum
-    regexMatchBytesInput
-  RegexMatchFlags* = set[RegexMatchFlag]
+
+func toMatchFlags*(f: RegexFlags): MatchFlags =
+  if regexArbitraryBytes in f:
+    result.incl mfBytesInput
+
+type
+  RegexLit* = distinct string
+    ## raw regex literal string
+  Regex* = object
+    ## deprecated
+    nfa*: Nfa
+    groupsCount*: int16
+    namedGroups*: OrderedTable[string, int16]
+    flags*: RegexFlags
+    litOpt*: LitOpt
   RegexMatch* = object
     ## deprecated
     captures*: Captures

--- a/src/regex/parser.nim
+++ b/src/regex/parser.nim
@@ -742,13 +742,14 @@ func verbosity(
   else:
     discard
 
-func parse*(expression: string): Exp =
+func parse*(expression: string, flags: RegexFlags = {}): Exp =
   ## convert a ``string`` regex expression
   ## into a ``Node`` expression
   result.s = newSeq[Node](expression.len)
   result.s.setLen 0
   var vb = newSeq[bool]()
-  let sc = expression.scan()
+  let bytesMode = regexArbitraryBytes in flags
+  let sc = expression.scan(bytesMode)
   for _ in sc:
     if sc.skipWhiteSpace(vb): continue
     result.s.add sc.subParse()

--- a/src/regex/scanner.nim
+++ b/src/regex/scanner.nim
@@ -3,6 +3,11 @@ import std/unicode
 import ./types
 import ./common
 
+func toByteRunes(s: string): seq[Rune] =
+  result = newSeqOfCap[Rune](s.len)
+  for c in s:
+    result.add Rune(c)
+
 type
   Scanner*[T: Rune|Node] = ref object
     ## A scanner is a common
@@ -17,10 +22,14 @@ proc newScanner*[T](s: seq[T]): Scanner[T] =
 proc scan*[T](s: seq[T]): Scanner[T] =
   newScanner(s)
 
-proc scan*(raw: string): Scanner[Rune] =
+proc scan*(raw: string, bytesMode = false): Scanner[Rune] =
+  let s = if bytesMode:
+    raw.toByteRunes
+  else:
+    raw.toRunes
   Scanner[Rune](
     raw: raw,
-    s: raw.toRunes,
+    s: s,
     pos: 0)
 
 iterator items*[T](sc: Scanner[T]): T =

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -243,7 +243,7 @@ const
     reNotWhiteSpaceAscii}
   matchableKind* = {
     reChar,
-    reCharCI,
+    reCharCi,
     reWord,
     reDigit,
     reWhiteSpace,

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -15,6 +15,13 @@ import ./common
 #     once acyclic imports are supported
 
 type
+  # needed by litopt and nfatype
+  # which would create a cyclic dep
+  # if defined in nfatype
+  RegexFlag* = enum
+    regexArbitraryBytes
+  RegexFlags* = set[RegexFlag]
+
   # exptype.nim
   RpnExp* = object
     s*: seq[Node]

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3119,3 +3119,20 @@ when not defined(js) or NimMajor >= 2:
     check replace("\xF0\xAF\xA2\x94\x94", re2(r"弢{2}", flags), "abc") == "abc"
     check replace("\xF0\xAF\xA2\x94\x94", re2(r"弢+", flags), "abc") == "abc"
     check replace("\x02\xF8\x95\x02\xF8\x95", re2(r"\x{2F895}{2}", flags), "abc") == "abc"
+    check match("\xF0\xAF\xA2\x94", re2(r".{4}", flags))
+    check match("\x02\xF8\x95", re2(r".+(?<=\x{2F895})", flags))
+    check(not match("\x02\xF8\x95\x95", re2(r".+(?<=\x{2F895})", flags)))
+    check match("\x02\xF8\x95\x02\xF8\x95", re2(r".+(?<=\x{2F895}+)", flags))
+    check match("\x02\xF8\x95\x02\xF8\x95", re2(r".+(?<=\x{2F895}{2})", flags))
+    check match("弢", re2(r".+(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
+    check match("弢", re2(r".+(?<=\xF0\xAF\xA2\x94)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=.{4})", flags))
+    block:
+      var m: RegexMatch2
+      check match("a", re2(r"a", flags)) and
+        m.groupsCount == 0
+      check match("\x02\xF8\x95", re2(r"\x{2F895}", flags)) and 
+        m.groupsCount == 0

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3136,3 +3136,48 @@ when not defined(js) or NimMajor >= 2:
         m.groupsCount == 0
       check match("\x02\xF8\x95", re2(r"\x{2F895}", flags)) and 
         m.groupsCount == 0
+
+  test "tarbitrary_bytes_misc5_subset":
+    let flags = {regexArbitraryBytes}
+    check findAllStr(r"x 弢 x 弢", re2(r"弢", flags)) == @["弢", "弢"]
+    check findAllStr(r"x Ⓐ x Ⓐ", re2(r"Ⓐ", flags)) == @["Ⓐ", "Ⓐ"]
+    check findAllStr(r"x Ϊ x Ϊ", re2(r"Ϊ", flags)) == @["Ϊ", "Ϊ"]
+    check findAllStr(r"x ΪⒶ弢 x", re2(r"ΪⒶ弢", flags)) == @["ΪⒶ弢"]
+    check findAllStr(r"x ΪⒶ弢 x ΪⒶ弢", re2(r"ΪⒶ弢", flags)) ==
+      @["ΪⒶ弢", "ΪⒶ弢"]
+    check findAllStr(r"1ΪⒶΪⒶ", re2(r"\dΪⒶ", flags)) == @["1ΪⒶ"]
+    check findAllStr(r"1ΪⒶ2ΪⒶ", re2(r"\dΪⒶ", flags)) == @["1ΪⒶ", "2ΪⒶ"]
+    check findAllStr(r"1ΪⒶΪⒶ2ΪⒶ", re2(r"\dΪⒶ", flags)) == @["1ΪⒶ", "2ΪⒶ"]
+    check findAllStr(r"1ⒶⒶ", re2(r"\dⒶ", flags)) == @["1Ⓐ"]
+    check findAllStr(r"1Ⓐ2Ⓐ", re2(r"\dⒶ", flags)) == @["1Ⓐ", "2Ⓐ"]
+    check findAllStr(r"1ⒶⒶ2Ⓐ", re2(r"\dⒶ", flags)) == @["1Ⓐ", "2Ⓐ"]
+    check findAllStr(r"abde", re2(r"abc?de", flags)) == @["abde"]
+    check findAllStr(r"abcde", re2(r"abc?de", flags)) == @["abcde"]
+    check findAllStr(r"abde1", re2(r"abc?de\d", flags)) == @["abde1"]
+    check findAllStr(r"abcde1", re2(r"abc?de\d", flags)) == @["abcde1"]
+    check findAllStr(r"abde1 abde2 abcde3", re2(r"abc?de\d", flags)) ==
+      @["abde1", "abde2", "abcde3"]
+    check findAllStr(r"1abc2abc3", re2(r"\wabc\w", flags)) == @["1abc2"]
+    check findAllStr(r"1abc2abc3abc4", re2(r"\wabc\w", flags)) == @["1abc2", "3abc4"]
+    check findAllStr(r"1abcabc", re2(r"\wabc", flags)) == @["1abc"]
+    check findAllStr(r"abcabcx", re2(r"abc\w", flags)) == @["abca"]
+    check findAllStr(r"abcabcabcd", re2(r"abc\w", flags)) == @["abca", "abcd"]
+    check findAllStr(r"aaab", re2(r"a\w", flags)) == @["aa", "ab"]
+    check findAllStr(r"1a2a3a4", re2(r"\wa\w", flags)) == @["1a2", "3a4"]
+    check findAllStr(r"1ΪⒶ弢2ΪⒶ弢3", re2(r"\wΪⒶ弢\w", flags)) == @["1ΪⒶ弢2"]
+    check findAllStr(r"1Ϊ弢2Ϊ弢3", re2(r"\wΪ弢\w", flags)) == @["1Ϊ弢2"]
+    check findAllStr(r"1Ϊ2Ϊ3", re2(r"\wΪ\w", flags)) == @["1Ϊ2"]
+    check findAllStr(r"1Ⓐ2Ⓐ3", re2(r"\wⒶ\w", flags)) == @["1Ⓐ2"]
+    check findAllStr(r"1弢2弢3", re2(r"\w弢\w", flags)) == @["1弢2"]
+    check findAllStr(r"1弢2弢3弢4", re2(r"\w弢\w", flags)) == @["1弢2", "3弢4"]
+    check findAllStr(r"abcdefhij", re2(r"((abc|def)|(hij))", flags)) ==
+      @["abc", "def", "hij"]
+    check findAllStr(r"abcdefhij", re2(r"((abc|def)+|(hij)+)", flags)) ==
+      @["abcdef", "hij"]
+    check findAllStr(r"1ΪⒶ弢2ΪⒶ弢34", re2(r"\dΪⒶ弢\d4", flags)) == @["2ΪⒶ弢34"]
+    check findAllStr(r"1Ϊ0弢2Ϊ0弢34", re2(r"\dΪ0弢\d\d", flags)) == @["2Ϊ0弢34"]
+    check findAllStr(r"1ΪⒶ弢23ΪⒶ弢4", re2(r"\dΪⒶ弢\d\d", flags)) == @["1ΪⒶ弢23"]
+    check findAllStr(r"1ΪⒶ弢23ΪⒶ弢45ΪⒶ弢6", re2(r"\dΪⒶ弢\d\d", flags)) ==
+      @["1ΪⒶ弢23"]
+    check findAllStr(r"1ΪⒶ弢23ΪⒶ弢45ΪⒶ弢67", re2(r"\dΪⒶ弢\d\d", flags)) ==
+      @["1ΪⒶ弢23", "5ΪⒶ弢67"]

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3144,6 +3144,37 @@ when not defined(js) or NimMajor >= 2:
       check match("\x02\xF8\x95", re2(r"\x{2F895}", flags)) and 
         m.groupsCount == 0
 
+  test "tarbitrary_bytes_flags":
+    let flags = {regexArbitraryBytes}
+    check match("abcd", re2(r".{4}", flags))
+    check match("abcd", re2(r"(?u).{4}", flags))
+    check match("abcd", re2(r"(?-u).{4}", flags))
+    check match("abcd", re2(r"(?s).{4}", flags))
+    check match("abcd", re2(r"(?-s).{4}", flags))
+    check match("abcd", re2(r"(?su).{4}", flags))
+    check match("abcd", re2(r"(?-su).{4}", flags))
+    check match("abcd", re2(r"(?s-u).{4}", flags))
+    check match("abcd", re2(r"(?u-s).{4}", flags))
+    #check match("弢", re2(r".{4}", flags))  # XXX should match
+    check match("弢", re2(r"(?u).{4}", flags))
+    check(not match("弢", re2(r"(?-u).{4}", flags)))
+    check(not match("\n", re2(r".", flags)))
+    check match("\n", re2(r"(?s).", flags))
+    check(not match("\n", re2(r"(?u).", flags)))
+    check(not match("\n", re2(r"(?-u).", flags)))
+    check match("\n", re2(r"(?su).", flags))
+    check match("\n", re2(r"(?s-u).", flags))
+    check(not match("\n", re2(r"(?-s).", flags)))
+    check(not match("\n", re2(r"(?-su).", flags)))
+    check(not match("\n", re2(r"(?u-s).", flags)))
+    check match("\xCE", re2(r"(?u)\w", flags))
+    check match("\xCE", re2(r"(?us)\w", flags))
+    check match("\xCE", re2(r"(?u-s)\w", flags))
+    check(not match("\xCE", re2(r"\w", flags)))
+    check(not match("\xCE", re2(r"(?-u)\w", flags)))
+    check(not match("\xCE", re2(r"(?-us)\w", flags)))
+    check(not match("\xCE", re2(r"(?s-u)\w", flags)))
+
   test "tarbitrary_bytes_misc5_subset":
     let flags = {regexArbitraryBytes}
     check findAllStr(r"x 弢 x 弢", re2(r"弢", flags)) == @["弢", "弢"]

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3130,6 +3130,7 @@ when not defined(js) or NimMajor >= 2:
     check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
     check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=弢)", flags))
     check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=.{4})", flags))
+    check findAllStr(r"ΪⒶ弢ΪⒶ弢x", re2(r"ΪⒶ弢\w", flags)) == @["ΪⒶ弢x"]
     block:
       var m: RegexMatch2
       check match("a", re2(r"a", flags)) and

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3119,17 +3119,18 @@ when not defined(js) or NimMajor >= 2:
     check replace("\xF0\xAF\xA2\x94\x94", re2(r"弢{2}", flags), "abc") == "abc"
     check replace("\xF0\xAF\xA2\x94\x94", re2(r"弢+", flags), "abc") == "abc"
     check replace("\x02\xF8\x95\x02\xF8\x95", re2(r"\x{2F895}{2}", flags), "abc") == "abc"
-    check match("\xF0\xAF\xA2\x94", re2(r".{4}", flags))
-    check match("\x02\xF8\x95", re2(r".+(?<=\x{2F895})", flags))
-    check(not match("\x02\xF8\x95\x95", re2(r".+(?<=\x{2F895})", flags)))
-    check match("\x02\xF8\x95\x02\xF8\x95", re2(r".+(?<=\x{2F895}+)", flags))
-    check match("\x02\xF8\x95\x02\xF8\x95", re2(r".+(?<=\x{2F895}{2})", flags))
-    check match("弢", re2(r".+(?<=弢)", flags))
-    check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
-    check match("弢", re2(r".+(?<=\xF0\xAF\xA2\x94)", flags))
-    check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
-    check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=弢)", flags))
-    check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=.{4})", flags))
+    # XXX (?u) should not be needed but . is buggy in ascii mode
+    check match("\xF0\xAF\xA2\x94", re2(r"(?u).{4}", flags))
+    check match("\x02\xF8\x95", re2(r"(?u).+(?<=\x{2F895})", flags))
+    check(not match("\x02\xF8\x95\x95", re2(r"(?u).+(?<=\x{2F895})", flags)))
+    check match("\x02\xF8\x95\x02\xF8\x95", re2(r"(?u).+(?<=\x{2F895}+)", flags))
+    check match("\x02\xF8\x95\x02\xF8\x95", re2(r"(?u).+(?<=\x{2F895}{2})", flags))
+    check match("弢", re2(r"(?u).+(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r"(?u).+(?<=弢)", flags))
+    check match("弢", re2(r"(?u).+(?<=\xF0\xAF\xA2\x94)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r"(?u).+(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r"(?u).{4}(?<=弢)", flags))
+    check match("\xF0\xAF\xA2\x94", re2(r"(?u).{4}(?<=.{4})", flags))
     block:
       check match("a", re2(r"(?u)\w", flags))
       check match("a", re2(r"\w", flags))

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3130,7 +3130,13 @@ when not defined(js) or NimMajor >= 2:
     check match("\xF0\xAF\xA2\x94", re2(r".+(?<=弢)", flags))
     check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=弢)", flags))
     check match("\xF0\xAF\xA2\x94", re2(r".{4}(?<=.{4})", flags))
-    check findAllStr(r"ΪⒶ弢ΪⒶ弢x", re2(r"ΪⒶ弢\w", flags)) == @["ΪⒶ弢x"]
+    block:
+      check match("a", re2(r"(?u)\w", flags))
+      check match("a", re2(r"\w", flags))
+      check match("\xCE", re2(r"(?u)\w", flags))
+      check(not match("\xCE", re2(r"\w", flags)))
+      check replace("ΪⒶ弢ΪⒶ弢x", re2(r"ΪⒶ弢\w", flags), "abc") == "ΪⒶ弢abc"
+      check replace("ΪⒶ弢ΪⒶ弢x", re2(r"(?u)ΪⒶ弢\w", flags), "abc") == "abc\xaaⒶ弢x"
     block:
       var m: RegexMatch2
       check match("a", re2(r"a", flags)) and


### PR DESCRIPTION
fixes #108

this needs some refactor and tests

```nim
let flags = {regexArbitraryBytes}
doAssert match("\xff", re2(r"\xff", flags))
doAssert replace("\xff", re2(r"\xff", flags), "abc") == "abc"
```

TODO:

- [x] change the parser so the pattern is iterated as chars instead of runes when setting the flag. So `re2("弢", flags)` matches `"弢"` and arbitrary bytes match arbitrary bytes.
- [x] tests
- [x] docs
