### PR TITLE
remove compile-time checks for unsupported, pre-1.6 Nim versions

### DIFF
--- a/src/regex/common.nim
+++ b/src/regex/common.nim
@@ -1,13 +1,6 @@
 import std/unicode
 import std/strutils
 
-when (NimMajor, NimMinor, NimPatch) < (0, 20, 0):
-  import sets
-  proc initHashSet*[T](size = 2): HashSet[T] =
-    result = initSet[T](size)
-  proc toHashSet*[T](keys: openArray[T]): HashSet[T] =
-    result = toSet[T](keys)
-
 type
   RegexError* = object of ValueError
   ## raised when the pattern

--- a/src/regex/compiler.nim
+++ b/src/regex/compiler.nim
@@ -24,7 +24,7 @@ func reImpl*(s: string, flags: RegexFlags = {}): Regex {.inline.} =
     flags: flags,
     litOpt: opt
   )
-  when defined(regexDotDir) and (NimMajor, NimMinor) >= (1, 2):
+  when defined(regexDotDir):
     const regexDotDir {.strdefine.} = ""
     graphToFile(result, regexDotDir)
 

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -1,7 +1,6 @@
 import std/strutils
-when (NimMajor, NimMinor) >= (1, 2):
-  import std/hashes
-  import std/os
+import std/hashes
+import std/os
 
 import ./nfatype
 import ./types
@@ -48,13 +47,12 @@ func graph*(nfa: Nfa): string =
 func graph*(regex: Regex): string =
   result = graph(regex.nfa)
 
-when (NimMajor, NimMinor) >= (1, 2):
-  func graphToFile*(regex: Regex, dir: string) =
-    {.noSideEffect.}:
-      if dir.len > 0:
-        let content = graph(regex)
-        let fname = $hash(content) & ".dot"
-        try:
-          writeFile(dir / fname, content)
-        except IOError:
-          debugEcho "write file error"
+func graphToFile*(regex: Regex, dir: string) =
+  {.noSideEffect.}:
+    if dir.len > 0:
+      let content = graph(regex)
+      let fname = $hash(content) & ".dot"
+      try:
+        writeFile(dir / fname, content)
+      except IOError:
+        debugEcho "write file error"

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -53,9 +53,6 @@ import ./types
 import ./nodematch
 import ./nfa
 
-when (NimMajor, NimMinor, NimPatch) < (0, 20, 0):
-  import common
-
 type
   LitNfa = Enfa
   End = seq[int16]

--- a/src/regex/nfa.nim
+++ b/src/regex/nfa.nim
@@ -193,10 +193,6 @@ func teClosure(
   for s in eNfa.s[state].next:
     teClosure(result, eNfa, s, processing, eTransitions)
 
-when (NimMajor, NimMinor, NimPatch) < (1,4,0) and not declared(IndexDefect):
-  # avoids a warning
-  type IndexDefect = IndexError
-
 func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
   ## Remove e-transitions and return
   ## remaining state transtions and

--- a/src/regex/parser.nim
+++ b/src/regex/parser.nim
@@ -479,14 +479,10 @@ func parseRepRange(sc: Scanner[Rune]): Node =
   var
     firstNum: int
     lastNum: int
-  when (NimMajor, NimMinor, NimPatch) < (0, 19, 9):
-    type MyError = ref OverflowError
-  else:
-    type MyError = ref ValueError
   try:
     discard parseInt(first, firstNum)
     discard parseInt(last, lastNum)
-  except MyError:
+  except ValueError:
     prettyCheck(
       false,
       "Invalid repetition range. Max value is $#" %% $int16.high)

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -1,6 +1,5 @@
 # XXX hack because of nfamatch compile warning
-when NimMajor >= 1:
-  {.used.}
+{.used.}
 
 import std/unicode
 import std/sets

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1342,146 +1342,144 @@ test "treplace":
       expected = "macht , geraden entfernen!"
     check text.replace(re"((\w)+\s*)", removeEvenWords) == expected
 
-# VM registry error on Nim < 1.1 (devel)
-when not defined(runTestAtCT) or (NimMajor, NimMinor) > (1, 0):
-  test "tmisc":
-    block:
-      var m: RegexMatch
-      check "abc".match(re"[^^]+", m)
-      check m.boundaries == 0 .. 2
-    check(not "^".isMatch(re"[^^]+"))
-    block:
-      var m: RegexMatch
-      check "kpd".match(re"[^al-obc]+", m)
-      check m.boundaries == 0 .. 2
-    check(not "abc".isMatch(re"[^al-obc]+"))
-    block:
-      var m: RegexMatch
-      check "almocb".match(re"[al-obc]+", m)
-      check m.boundaries == 0 .. 5
-    check(not "defzx".isMatch(re"[al-obc]+"))
+test "tmisc":
+  block:
+    var m: RegexMatch
+    check "abc".match(re"[^^]+", m)
+    check m.boundaries == 0 .. 2
+  check(not "^".isMatch(re"[^^]+"))
+  block:
+    var m: RegexMatch
+    check "kpd".match(re"[^al-obc]+", m)
+    check m.boundaries == 0 .. 2
+  check(not "abc".isMatch(re"[^al-obc]+"))
+  block:
+    var m: RegexMatch
+    check "almocb".match(re"[al-obc]+", m)
+    check m.boundaries == 0 .. 5
+  check(not "defzx".isMatch(re"[al-obc]+"))
 
-    # From http://www.regular-expressions.info/examples.html
-    # Grabbing HTML Tags
-    block:
-      var m: RegexMatch
-      check "one<TAG>two</TAG>three".find(re"<TAG\b[^>]*>(.*?)</TAG>", m)
-      check m.boundaries == 3 .. 16
-    check("one<TAG>two</TAG>three".findWithCapt(
-      re"<TAG\b[^>]*>(.*?)</TAG>") == @[@["two"]])
-    # IP Addresses
-    block:
-      const ip = re"""(?x)
-      \b
-      (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-      \.
-      (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-      \.
-      (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-      \.
-      (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-      \b
-      """
-      check "127.0.0.1".findWithCapt(ip) ==
-        @[@["127"], @["0"], @["0"], @["1"]]
-      check(not "127.0.0.999".isMatch(ip))
-    # Floating Point Numbers
-    block:
-      var m: RegexMatch
-      check "3.14".find(re"^[-+]?[0-9]*\.?[0-9]+$", m)
-      check m.boundaries == 0 .. 3
-    check "1.602e-19".findWithCapt(
-      re"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$") == @[@["e-19"]]
-    # E-mail Addresses
-    block:
-      const email = re"""(?x)
-      \b
-      [a-zA-Z0-9._%+-]+
-      @
-      (?:[a-zA-Z0-9-]+\.)+
-      [a-zA-Z]{2,4}
-      \b
-      """
-      var m: RegexMatch
-      check "john@server.department.company.com".find(email, m)
-      check m.boundaries == 0 .. 33
-      check(not "john@aol...com".isMatch(email))
-    block:
-      const email = re"""(?x)
-      [a-z0-9!#$%&'*+/=?^_`{|}~-]+
-      (?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*
-      @
-      (?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+
-      [a-z0-9](?:[a-z0-9-]*[a-z0-9])?
-      """
-      check "john@server.department.company.com".isMatch(email)
-      check(not "john@aol...com".isMatch(email))
-    block:
-      const email = re"""(?x)
-      (?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+
-      (?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"
-      (?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|
-      \\[\x01-\x09\x0b\x0c\x0e-\x7f])*"
-      )@
-      (?:
-      (?:[a-z0-9]
-      (?:[a-z0-9-]*[a-z0-9])?\.
-      )+[a-z0-9]
-      (?:[a-z0-9-]*[a-z0-9])?|\[
-      (?:
-      (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.
-      ){3}
-      (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:
-      (?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|
-      \\[\x01-\x09\x0b\x0c\x0e-\x7f])+
-      )\]
-      )
-      """
-      check "john@server.department.company.com".isMatch(email)
-      check(not "john@aol...com".isMatch(email))
-    # Date Validation
-    block:
-      const date = re"""(?x)
-      ^((?:19|20)\d\d)[- /.]
-      (0[1-9]|1[012])[- /.]
-      (0[1-9]|[12][0-9]|3[01])$
-      """
-      check "1999-01-01".findWithCapt(date) ==
-        @[@["1999"], @["01"], @["01"]]
-      check "1999/01-01".findWithCapt(date) ==
-        @[@["1999"], @["01"], @["01"]]
-      check(not "1999-13-33".isMatch(date))
-    # Near operator emulation
-    block:
-      const nope = re"\bword1\W+(?:\w+\W+){1,6}?word2\b"
-      check(not "word1 word2".isMatch(nope))
-      check "word1 1 word2".isMatch(nope)
-      check "word1 1 2 3 4 5 6 word2".isMatch(nope)
-      check(not "word1 1 2 3 4 5 6 7 word".isMatch(nope))
+  # From http://www.regular-expressions.info/examples.html
+  # Grabbing HTML Tags
+  block:
+    var m: RegexMatch
+    check "one<TAG>two</TAG>three".find(re"<TAG\b[^>]*>(.*?)</TAG>", m)
+    check m.boundaries == 3 .. 16
+  check("one<TAG>two</TAG>three".findWithCapt(
+    re"<TAG\b[^>]*>(.*?)</TAG>") == @[@["two"]])
+  # IP Addresses
+  block:
+    const ip = re"""(?x)
+    \b
+    (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    \.
+    (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    \.
+    (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    \.
+    (25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    \b
+    """
+    check "127.0.0.1".findWithCapt(ip) ==
+      @[@["127"], @["0"], @["0"], @["1"]]
+    check(not "127.0.0.999".isMatch(ip))
+  # Floating Point Numbers
+  block:
+    var m: RegexMatch
+    check "3.14".find(re"^[-+]?[0-9]*\.?[0-9]+$", m)
+    check m.boundaries == 0 .. 3
+  check "1.602e-19".findWithCapt(
+    re"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$") == @[@["e-19"]]
+  # E-mail Addresses
+  block:
+    const email = re"""(?x)
+    \b
+    [a-zA-Z0-9._%+-]+
+    @
+    (?:[a-zA-Z0-9-]+\.)+
+    [a-zA-Z]{2,4}
+    \b
+    """
+    var m: RegexMatch
+    check "john@server.department.company.com".find(email, m)
+    check m.boundaries == 0 .. 33
+    check(not "john@aol...com".isMatch(email))
+  block:
+    const email = re"""(?x)
+    [a-z0-9!#$%&'*+/=?^_`{|}~-]+
+    (?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*
+    @
+    (?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+
+    [a-z0-9](?:[a-z0-9-]*[a-z0-9])?
+    """
+    check "john@server.department.company.com".isMatch(email)
+    check(not "john@aol...com".isMatch(email))
+  block:
+    const email = re"""(?x)
+    (?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+
+    (?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"
+    (?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|
+    \\[\x01-\x09\x0b\x0c\x0e-\x7f])*"
+    )@
+    (?:
+    (?:[a-z0-9]
+    (?:[a-z0-9-]*[a-z0-9])?\.
+    )+[a-z0-9]
+    (?:[a-z0-9-]*[a-z0-9])?|\[
+    (?:
+    (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.
+    ){3}
+    (?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:
+    (?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|
+    \\[\x01-\x09\x0b\x0c\x0e-\x7f])+
+    )\]
+    )
+    """
+    check "john@server.department.company.com".isMatch(email)
+    check(not "john@aol...com".isMatch(email))
+  # Date Validation
+  block:
+    const date = re"""(?x)
+    ^((?:19|20)\d\d)[- /.]
+    (0[1-9]|1[012])[- /.]
+    (0[1-9]|[12][0-9]|3[01])$
+    """
+    check "1999-01-01".findWithCapt(date) ==
+      @[@["1999"], @["01"], @["01"]]
+    check "1999/01-01".findWithCapt(date) ==
+      @[@["1999"], @["01"], @["01"]]
+    check(not "1999-13-33".isMatch(date))
+  # Near operator emulation
+  block:
+    const nope = re"\bword1\W+(?:\w+\W+){1,6}?word2\b"
+    check(not "word1 word2".isMatch(nope))
+    check "word1 1 word2".isMatch(nope)
+    check "word1 1 2 3 4 5 6 word2".isMatch(nope)
+    check(not "word1 1 2 3 4 5 6 7 word".isMatch(nope))
 
-    # Unicode
-    block:
-      var m: RegexMatch
-      check "①②③".find(re"①②③", m)
-      check m.boundaries == 0 ..< "①②③".len
-    block:
-      var m: RegexMatch
-      check "①②③④⑤".find(re"①②③", m)
-      check m.boundaries == 0 ..< "①②③".len
-    block:
-      var m: RegexMatch
-      check "①②③".find(re"①(②)③", m)
-      check m.boundaries == 0 ..< "①②③".len
-    check "①②③".findWithCapt(re"①(②)③") == @[@["②"]]
-    block:
-      var m: RegexMatch
-      check "①②③".find(re"[①②③]*", m)
-      check m.boundaries == 0 ..< "①②③".len
-    #
-    block:
-      var m: RegexMatch
-      check "①②③".find(re"[^④⑤]*", m)
-      check m.boundaries == 0 ..< "①②③".len
+  # Unicode
+  block:
+    var m: RegexMatch
+    check "①②③".find(re"①②③", m)
+    check m.boundaries == 0 ..< "①②③".len
+  block:
+    var m: RegexMatch
+    check "①②③④⑤".find(re"①②③", m)
+    check m.boundaries == 0 ..< "①②③".len
+  block:
+    var m: RegexMatch
+    check "①②③".find(re"①(②)③", m)
+    check m.boundaries == 0 ..< "①②③".len
+  check "①②③".findWithCapt(re"①(②)③") == @[@["②"]]
+  block:
+    var m: RegexMatch
+    check "①②③".find(re"[①②③]*", m)
+    check m.boundaries == 0 ..< "①②③".len
+  #
+  block:
+    var m: RegexMatch
+    check "①②③".find(re"[^④⑤]*", m)
+    check m.boundaries == 0 ..< "①②③".len
 
 test "tlook_around":
   check "ab".isMatch(re"a(?=b)\w")
@@ -2250,23 +2248,21 @@ test "tmisc2_5":
   check match("650-253-0001", re"[0-9]+..*", m)
   check(not match("abc-253-0001", re"[0-9]+..*", m))
   check(not match("6", re"[0-9]+..*", m))
-  # VM registry error on Nim < 1.1 (devel)
-  when not defined(runTestAtCT) or (NimMajor, NimMinor) > (1, 0):
-    block:
-      const re1 = re"((11)*)+(111)*"
-      check match("", re1)
-      check match("11", re1)
-      check match("111", re1)
-      check match("11111", re1)
-      check match("1111111", re1)
-      check match("1111111111", re1)
-      check(not match("1", re1))
-    block:
-      const re1 = re"(11)+(111)*"
-      check(not match("", re1))
-      check match("11", re1)
-      check(not match("111", re1))
-      check match("11111", re1)
+  block:
+    const re1 = re"((11)*)+(111)*"
+    check match("", re1)
+    check match("11", re1)
+    check match("111", re1)
+    check match("11111", re1)
+    check match("1111111", re1)
+    check match("1111111111", re1)
+    check(not match("1", re1))
+  block:
+    const re1 = re"(11)+(111)*"
+    check(not match("", re1))
+    check match("11", re1)
+    check(not match("111", re1))
+    check match("11111", re1)
 
 test "tmisc2_6":
   block:


### PR DESCRIPTION
Since [Drop support for Nim < 1.6](https://github.com/nitely/nim-regex/commit/2da4b861ba6638599f1fa494c4d6ba6fc7da8512) this is all unused/unreachable code.