### PR TITLE
Reorder epsilon transitions

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1562,10 +1562,10 @@ when isMainModule:
 
   doAssert graph(toRegex(re2"^a+$")) == """digraph graphname {
     0 [label="q0";color=blue];
-    2 [label="q1";color=black];
-    4 [label="q2";color=blue];
-    0 -> 2 [label="a, {^}, i=0"];
-    2 -> 2 [label="a, i=0"];2 -> 4 [label="{eoe}, {$}, i=1"];
+    1 [label="q1";color=black];
+    3 [label="q2";color=blue];
+    0 -> 1 [label="a, {^}, i=0"];
+    1 -> 1 [label="a, i=0"];1 -> 3 [label="{eoe}, {$}, i=1"];
 }
 """
 

--- a/src/regex/dotgraph.nim
+++ b/src/regex/dotgraph.nim
@@ -5,6 +5,14 @@ import std/os
 import ./nfatype
 import ./types
 
+func getEpsilonTransitions(nfa: Nfa, n: Node, nti: int): seq[int] =
+  doAssert not isEpsilonTransition(n)
+  doAssert nti <= n.next.len-1
+  for i in nti+1 .. n.next.len-1:
+    if not isEpsilonTransition(nfa.s[n.next[i]]):
+      break
+    result.add n.next[i]
+
 func color(n: Node): string =
   case n.kind
   of matchableKind: "black"
@@ -29,12 +37,13 @@ func graph*(nfa: Nfa): string =
     result.add tab
     var t = ""
     var ii = 0
-    for n2 in n.next:
+    for nti, n2 in pairs n.next:
       if isEpsilonTransition(nfa.s[n2]):
+        continue
+      for n3 in getEpsilonTransitions(nfa, n, nti):
         if t.len > 0:
           t &= ", "
-        t &= $nfa.s[n2]
-        continue
+        t &= $nfa.s[n3]
       if t.len > 0:
         t = ", {" & t & "}"
       let label = ($nfa.s[n2] & t & ", i=" & $ii).replace(r"\", r"\\")

--- a/src/regex/nfa.nim
+++ b/src/regex/nfa.nim
@@ -226,15 +226,15 @@ func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
     doAssert statesMap[qa] > -1
     result.s[statesMap[qa]].next.setLen 0
     for qb, transitions in closure.items:
+      if statesMap[qb] == -1:
+        result.s.add eNfa.s[qb]
+        statesMap[qb] = result.s.len.int16-1
+      result.s[statesMap[qa]].next.add statesMap[qb]
       for eti in transitions:
         if statesMap[eti] == -1:
           result.s.add eNfa.s[eti]
           statesMap[eti] = result.s.len.int16-1
         result.s[statesMap[qa]].next.add statesMap[eti]
-      if statesMap[qb] == -1:
-        result.s.add eNfa.s[qb]
-        statesMap[qb] = result.s.len.int16-1
-      result.s[statesMap[qa]].next.add statesMap[qb]
       if qb notin qu:
         qu.incl qb
         qw.addFirst qb

--- a/src/regex/nfa.nim
+++ b/src/regex/nfa.nim
@@ -147,8 +147,8 @@ func eNfa*(exp: RpnExp): Enfa {.raises: [RegexError].} =
   result.s.add initSkipNode(states)
 
 type
-  Etransitions = seq[int16]  # xxx transitions
-  TeClosure = seq[(int16, Etransitions)]
+  Transitions = seq[int16]
+  TeClosure = seq[(int16, Transitions)]
 
 func isEpsilonTransition2(n: Node): bool {.inline.} =
   result = case n.kind
@@ -164,24 +164,24 @@ func teClosure(
   eNfa: Enfa,
   state: int16,
   processing: var seq[int16],
-  eTransitions: Etransitions
+  transitions: Transitions
 ) =
-  var eTransitionsCurr = eTransitions
+  var transitionsCurr = transitions
   if isEpsilonTransition2 eNfa.s[state]:
-    eTransitionsCurr.add state
+    transitionsCurr.add state
   if eNfa.s[state].kind in matchableKind + {reEOE}:
-    result.add (state, eTransitionsCurr)
+    result.add (state, transitionsCurr)
     return
   for i, s in pairs eNfa.s[state].next:
     # Enter loops only once. "a", re"(a*)*" -> ["a", ""]
     if eNfa.s[state].kind in repetitionKind:
       if s notin processing or i == int(eNfa.s[state].isGreedy):
         processing.add s
-        teClosure(result, eNfa, s, processing, eTransitionsCurr)
+        teClosure(result, eNfa, s, processing, transitionsCurr)
         discard processing.pop()
       # else skip loop
     else:
-      teClosure(result, eNfa, s, processing, eTransitionsCurr)
+      teClosure(result, eNfa, s, processing, transitionsCurr)
 
 func teClosure(
   result: var TeClosure,
@@ -190,9 +190,9 @@ func teClosure(
   processing: var seq[int16]
 ) =
   doAssert processing.len == 0
-  var eTransitions: Etransitions
+  var transitions: Transitions
   for s in eNfa.s[state].next:
-    teClosure(result, eNfa, s, processing, eTransitions)
+    teClosure(result, eNfa, s, processing, transitions)
 
 func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
   ## Remove e-transitions and return
@@ -225,8 +225,8 @@ func eRemoval*(eNfa: Enfa): Nfa {.raises: [].} =
     teClosure(closure, eNfa, qa, processing)
     doAssert statesMap[qa] > -1
     result.s[statesMap[qa]].next.setLen 0
-    for qb, eTransitions in closure.items:
-      for eti in eTransitions:
+    for qb, transitions in closure.items:
+      for eti in transitions:
         if statesMap[eti] == -1:
           result.s.add eNfa.s[eti]
           statesMap[eti] = result.s.len.int16-1

--- a/src/regex/nfafindall.nim
+++ b/src/regex/nfafindall.nim
@@ -162,7 +162,6 @@ func submatch(
           smi = -1
           break
         smB.add (nt0, captx, bounds.a .. i-1)
-      inc nti
     inc smi
   swap smA, smB
 

--- a/src/regex/nfafindall.nim
+++ b/src/regex/nfafindall.nim
@@ -125,11 +125,16 @@ func submatch(
   var eoeFound = false
   var smi = 0
   while smi < smA.len:
+    let L = nfa[n].next.len
     var nti = 0
-    while nti <= nfa[n].next.len-1:
-      matched = true
+    while nti < L:
+      let isEoe = ntn.kind == reEoe
+      let nt0 = nt
+      matched = not smB.hasState(nt) and
+        (ntn.match(c.Rune) or ntn.kind == reEoe)
+      inc nti
       captx = capt
-      while isEpsilonTransition(ntn):
+      while nti < L and isEpsilonTransition(ntn):
         if matched:
           case ntn.kind
           of groupKind:
@@ -146,10 +151,8 @@ func submatch(
             doAssert false
             discard
         inc nti
-      if matched and
-          not smB.hasState(nt) and
-          (ntn.match(c.Rune) or ntn.kind == reEoe):
-        if ntn.kind == reEoe:
+      if matched:
+        if isEoe:
           #debugEcho "eoe ", bounds, " ", ms.m
           ms.m.add (captx, bounds.a .. i-1)
           smA.clear()
@@ -158,7 +161,7 @@ func submatch(
             smA.add (0'i16, -1'i32, i .. i-1)
           smi = -1
           break
-        smB.add (nt, captx, bounds.a .. i-1)
+        smB.add (nt0, captx, bounds.a .. i-1)
       inc nti
     inc smi
   swap smA, smB

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -165,11 +165,16 @@ func submatch(
   while smi < smA.len:
     if capt != -1:
       capts.keepAlive capt
+    let L = nfa[n].next.len
     var nti = 0
-    while nti <= nfa[n].next.len-1:
-      matched = true
+    while nti < L:
+      let isEoe = ntn.kind == reEoe
+      let nt0 = nt
+      matched = not smB.hasState(nt) and
+        (ntn.match(c.Rune) or ntn.kind == reEoe)
+      inc nti
       captx = capt
-      while isEpsilonTransition(ntn):
+      while nti < L and isEpsilonTransition(ntn):
         if matched:
           case ntn.kind
           of reGroupStart:
@@ -192,10 +197,8 @@ func submatch(
             doAssert false
             discard
         inc nti
-      if matched and
-          not smB.hasState(nt) and
-          (ntn.match(c.Rune) or ntn.kind == reEoe):
-        if ntn.kind == reEoe:
+      if matched:
+        if isEoe:
           #debugEcho "eoe ", bounds, " ", ms.m
           ms.add (captx, bounds.a .. i-1)
           smA.clear()
@@ -204,8 +207,7 @@ func submatch(
             smA.add (0'i16, -1'i32, i .. i-1)
           smi = -1
           break
-        smB.add (nt, captx, bounds.a .. i-1)
-      inc nti
+        smB.add (nt0, captx, bounds.a .. i-1)
     inc smi
   swap smA, smB
   capts.recycle()

--- a/src/regex/nfamacro.nim
+++ b/src/regex/nfamacro.nim
@@ -267,6 +267,7 @@ func genLookaroundMatch(
 
 func getEpsilonTransitions(nfa: Nfa, n: Node, nti: int): seq[int] =
   doAssert not isEpsilonTransition(n)
+  doAssert nti <= n.next.len-1
   for i in nti+1 .. n.next.len-1:
     if not isEpsilonTransition(nfa.s[n.next[i]]):
       break

--- a/src/regex/nfamacro.nim
+++ b/src/regex/nfamacro.nim
@@ -34,7 +34,7 @@ type
     nfa: Nfa,
     look: Lookaround,
     flags: set[MatchFlag]
-  ): NimNode {.noSideEffect, raises: [].}
+  ): NimNode {.nimcall, noSideEffect, raises: [].}
   Lookaround = object
     ahead, behind: Sig
     smL: NimNode
@@ -266,11 +266,11 @@ func genLookaroundMatch(
     removeLast `smL`
 
 func getEpsilonTransitions(nfa: Nfa, n: Node, nti: int): seq[int] =
-  for i in countdown(nti-1, 0):
+  doAssert not isEpsilonTransition(n)
+  for i in nti+1 .. n.next.len-1:
     if not isEpsilonTransition(nfa.s[n.next[i]]):
       break
     result.add n.next[i]
-  result.reverse()
 
 func genMatchedBody(
   smB, ntLit, capt, bounds, matched, captx,

--- a/src/regex/nfamatch.nim
+++ b/src/regex/nfamatch.nim
@@ -108,7 +108,6 @@ template nextStateTpl(bwMatch = false): untyped {.dirty.} =
         inc nti
       if matched:
         smB.add (nt0, captx, bounds2)
-      inc nti
   swap smA, smB
 
 func matchImpl(

--- a/src/regex/nfamatch2.nim
+++ b/src/regex/nfamatch2.nim
@@ -91,11 +91,15 @@ template nextStateTpl(bwMatch = false): untyped {.dirty.} =
       if not smB.hasState n:
         smB.add (n, capt, bounds)
       break
+    let L = nfa.s[n].next.len
     var nti = 0
-    while nti <= nfa.s[n].next.len-1:
-      matched = true
+    while nti < L:
+      let nt0 = nt
+      matched = not smB.hasState(nt) and
+        (ntn.match(c) or (anchored and ntn.kind == reEoe))
+      inc nti
       captx = capt
-      while isEpsilonTransition(ntn):
+      while nti < L and isEpsilonTransition(ntn):
         if matched:
           case ntn.kind
           of reGroupStart:
@@ -124,11 +128,8 @@ template nextStateTpl(bwMatch = false): untyped {.dirty.} =
             doAssert false
             discard
         inc nti
-      if matched and
-          not smB.hasState(nt) and
-          (ntn.match(c) or (anchored and ntn.kind == reEoe)):
-        smB.add (nt, captx, bounds2)
-      inc nti
+      if matched:
+        smB.add (nt0, captx, bounds2)
   swap smA, smB
   capts.recycle()
 


### PR DESCRIPTION
Follow up #129

Reorder the epsilon transitions to be evaluated after the matchable node: `@[matchable_node_idx, epsilon_transition_idx]`.

It helps avoiding pointless capts evaluation on regex with alternations: `(foo|bar|...)`. Currently capts are evaluated for all alternations, even if only one matches.

This improves #138 somewhat when using findAll (`contains` uses the no-capts optimization so no changes there).

This branch:

```
time nim c -r --threads:off -d:danger tests/test_bug/testbug.nim
compiled
2000
ok

real    0m7.232s
user    0m7.194s
sys     0m0.037s
```

Master:

```
time nim c -r --threads:off -d:danger tests/test_bug/testbug.nim
compiled
2000
ok

real    0m19.415s
user    0m20.467s
sys     0m0.270s
```