### PR TITLE
Comptime checked and runtime compiled regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ tests/tests2
 tests/tests2.js
 tests/tests_misc
 tests/tests_misc.js
+tests/tests_tilde
+tests/tests_tilde.js
 tests/test_bug
 docs/ugh
 bin/*

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1569,6 +1569,7 @@ when isMainModule:
 
   doAssert ~"ab" in "abcd"
   doAssert ~"zx" notin "abcd"
+  doAssert not compiles(~"(+)")
 
   # bug: raises invalid utf8 regex in Nim 1.0 + js target
   when not defined(js) or NimMajor >= 2:

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -539,6 +539,11 @@ func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =
       tildes[s] = toRegex2 reImpl(s)
       return tildes[s]
 
+func regexDestroyCache* {.gcsafe.} =
+  ## Destroy tilde (``~``) cache.
+  {.cast(noSideEffect).}:
+    tildes = default(Table[string, Regex2])
+
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.
   ## Slice of start > end are empty

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -508,7 +508,7 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-func `~`*(s: static[string]): Regex2 =
+func `~`*(s: static string): Regex2 =
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
     var reg {.global.} = re2(s)

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1566,6 +1566,7 @@ when isMainModule:
   doAssert match("A", re2"(?xi)     a")
   doAssert(not match("A", re2"((?xi))     a"))
   doAssert(not match("A", re2"(?xi:(?xi)     )a"))
+  doAssert not compiles(re2"(+)")
 
   doAssert ~"ab" in "abcd"
   doAssert ~"zx" notin "abcd"

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -436,7 +436,6 @@ To compile the regex at runtime pass the regex expression as a ``var/let``.
 
 ]##
 
-import std/locks
 import std/tables
 import std/sequtils
 import std/unicode

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -508,16 +508,28 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-func `~`*(s: static string): Regex2 =
+import locks
+var sigils {.compileTime.} = newSeq[string]()
+var sigilre = initTable[string, Regex2]()
+var sigillock: Lock
+initLock(sigillock)
+
+func `~`*(s: static string): Regex2 {.raises: [RegexError].} =
   ## Compile a regex at runtime.
   ## The compiled regex is cached and reused.
   ## It gets compiled once in a program lifetime.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  {.cast(noSideEffect), cast(gcsafe).}:
-    var reg {.global.} = toRegex2 reImpl(s)
-    return reg
+  when nimvm:
+    return toRegex2 reImpl(s)
+  else:
+    {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+      withLock sigillock:
+        if s in sigilre:
+          return sigilre[s]
+        sigilre[s] = toRegex2 reImpl(s)
+        return sigilre[s]
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -517,7 +517,7 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-var tildesct {.compileTime.} = initTable[string, Regex2]()
+var tildesct {.compileTime.}: Table[string, Regex2]
 var tildes {.threadvar.}: Table[string, Regex2]
 
 func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -509,6 +509,11 @@ proc reCheck(s: string) {.compileTime.} =
     raise newException(RegexError, getCurrentExceptionMsg())
 
 func `~`*(s: static string): Regex2 =
+  ## Compile a regex at runtime.
+  ## The compiled regex is cached and reused.
+  ## It gets compiled once in a program lifetime.
+  ## The regex is validated at compile-time,
+  ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
     var reg {.global.} = toRegex2 reImpl(s)

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -359,8 +359,8 @@ Tilde
 #####
 
 The tilde operator (``~``) compiles a regex literal at runtime,
-and it cache it for later usage. The regex is validated
-at compile-time. Since it does not generate a compiled regex,
+and it caches it for later usage. The regex is validated
+at compile-time. Since it does not generates code for the compiled regex,
 compilation time can be faster, and the resulting binary smaller.
 Do not assign it to a ``const``.
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -504,14 +504,14 @@ when not defined(forceRegexAtRuntime):
 
 proc reCheck(s: string) {.compileTime.} =
   try:
-    discard re2(s)
+    discard reCt(s)
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
 func `~`*(s: static string): Regex2 =
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
-    var reg {.global.} = re2(s)
+    var reg {.global.} = toRegex2 reImpl(s)
     return reg
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -505,7 +505,7 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-func `~`*(s: static[string]): Regex2 =
+func `~`*(s: static string): Regex2 =
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
     var reg {.global.} = re2(s)

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -355,6 +355,25 @@ regex is parsed as a byte sequence. The ``Ⓐ`` character
 is composed of multiple bytes (``\xe2\x92\xb6``),
 and only the last byte is affected by the ``+`` operator.
 
+Tilde
+#####
+
+The tilde operator (``~``) compiles a regex literal at runtime,
+and it cache it for later usage. The regex is validated
+at compile-time. Since it does not generate a compiled regex,
+compilation time can be faster, and the resulting binary smaller.
+Do not assign it to a ``const``.
+
+.. code-block:: nim
+    :test:
+    let text = "abc"
+    block:
+      doAssert match(text, ~".+")
+    block:
+      func myFn(s: string, r: Regex2) =
+        doAssert match(s, r)
+      myFn(text, ~".+")
+
 Compile the regex at compile time
 #################################
 
@@ -398,17 +417,6 @@ Using a ``const`` can avoid confusion when passing flags:
 
 Compile the regex at runtime
 ############################
-
-.. note::
-    Consider `compiling the regex at compile-time <#examples-compile-the-regex-at-compile-time>`_
-    whenever possible.
-
-Most of the time compiling the regex at runtime can be avoided,
-and it should be avoided. Nim has really good compile-time
-capabilities like reading files, constructing strings,
-and so on. However, it cannot be helped in cases where
-the regex is passed to the program at runtime (from terminal input,
-network, or text files).
 
 To compile the regex at runtime pass the regex expression as a ``var/let``.
 
@@ -506,21 +514,25 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
+var tildesct {.compileTime.} = initTable[string, Regex2]()
 var tildes = initTable[string, Regex2]()
 var tildelock: Lock
 initLock(tildelock)
 
-func `~`*(s: static string): Regex2 {.raises: [RegexError].} =
+func `~`*(s: static string): lent Regex2 {.raises: [RegexError].} =
   ## Compile a regex at runtime.
-  ## The compiled regex is cached and reused.
+  ## The compiled regex is cached for later usage.
   ## It gets compiled once in a program lifetime.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  when nimvm:
-    return toRegex2 reImpl(s)
-  else:
-    {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+  {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+    when nimvm:
+      if s in tildesct:
+        return tildesct[s]
+      tildesct[s] = toRegex2 reImpl(s)
+      return tildesct[s]
+    else:
       withLock tildelock:
         if s in tildes:
           return tildes[s]

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -501,14 +501,14 @@ when not defined(forceRegexAtRuntime):
 
 proc reCheck(s: string) {.compileTime.} =
   try:
-    discard re2(s)
+    discard reCt(s)
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
 func `~`*(s: static string): Regex2 =
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
-    var reg {.global.} = re2(s)
+    var reg {.global.} = toRegex2 reImpl(s)
     return reg
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -505,28 +505,16 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-import locks
-var sigils {.compileTime.} = newSeq[string]()
-var sigilre = initTable[string, Regex2]()
-var sigillock: Lock
-initLock(sigillock)
-
-func `~`*(s: static string): Regex2 {.raises: [RegexError].} =
+func `~`*(s: static string): Regex2 {.nodestroy.} =
   ## Compile a regex at runtime.
   ## The compiled regex is cached and reused.
   ## It gets compiled once in a program lifetime.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  when nimvm:
-    return toRegex2 reImpl(s)
-  else:
-    {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
-      withLock sigillock:
-        if s in sigilre:
-          return sigilre[s]
-        sigilre[s] = toRegex2 reImpl(s)
-        return sigilre[s]
+  {.cast(noSideEffect), cast(gcsafe).}:
+    var reg {.global.} = toRegex2 reImpl(s)
+    return reg
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -505,16 +505,28 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-func `~`*(s: static string): Regex2 =
+import locks
+var sigils {.compileTime.} = newSeq[string]()
+var sigilre = initTable[string, Regex2]()
+var sigillock: Lock
+initLock(sigillock)
+
+func `~`*(s: static string): Regex2 {.raises: [RegexError].} =
   ## Compile a regex at runtime.
   ## The compiled regex is cached and reused.
   ## It gets compiled once in a program lifetime.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  {.cast(noSideEffect), cast(gcsafe).}:
-    var reg {.global.} = toRegex2 reImpl(s)
-    return reg
+  when nimvm:
+    return toRegex2 reImpl(s)
+  else:
+    {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+      withLock sigillock:
+        if s in sigilre:
+          return sigilre[s]
+        sigilre[s] = toRegex2 reImpl(s)
+        return sigilre[s]
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -507,39 +507,32 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
-proc reCheck(s: string) {.compileTime.} =
+proc reCheck(s: string): string =
   try:
     discard reCt(s)
-  except RegexError:
-    raise newException(RegexError, getCurrentExceptionMsg())
+    return ""
+  except RegexError as err:
+    return "[RegexError] " & err.msg
 
-var tildesct {.compileTime.}: Table[string, Regex2]
-var tildes {.threadvar.}: Table[string, Regex2]
-
-func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =
-  ## Compile a regex at runtime.
-  ## The compiled regex is cached for later usage.
-  ## It gets compiled once per thread.
-  ## The regex is validated at compile-time,
-  ## and so it may only raise a `RegexError` at compile-time.
-  static: reCheck(s)
-  {.cast(noSideEffect), cast(raises: [RegexError]).}:
+func `~`*(s: static string): lent Regex2 =
+  ## Return a compiled regex.
+  ## The regex is:
+  ## - Validated at compile-time.
+  ## - Compiled at runtime.
+  ## - Cached for later usage.
+  when reCheck(s) != "":
+    {.error: reCheck(s).}
+  {.cast(noSideEffect), cast(gcsafe), cast(raises: []).}:
     when nimvm:
-      {.cast(gcsafe).}:
-        if s in tildesct:
-          return tildesct[s]
-        tildesct[s] = toRegex2 reImpl(s)
-        return tildesct[s]
+      const rvm = toRegex2 reImpl(s)
+      return rvm
     else:
-      if s in tildes:
-        return tildes[s]
-      tildes[s] = toRegex2 reImpl(s)
-      return tildes[s]
-
-func regexDestroyCache* {.gcsafe.} =
-  ## Destroy tilde (``~``) cache.
-  {.cast(noSideEffect).}:
-    tildes = default(Table[string, Regex2])
+      when defined(gcDestructors):
+        var reg {.global.} = toRegex2 reImpl(s)
+        return reg
+      else:
+        const reg = toRegex2 reImpl(s)
+        return reg
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.
@@ -1256,6 +1249,7 @@ when isMainModule:
   doAssert(not match("A", re2"(?xi:(?xi)     )a"))
   doAssert not compiles(re2"(+)")
 
+  doAssert ~r"\w" in "abcd"
   doAssert ~"ab" in "abcd"
   doAssert ~"zx" notin "abcd"
   doAssert not compiles(~"(+)")

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -507,14 +507,14 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
-func reCheck(T: type Regex2, s: string): bool {.compileTime.} =
+func check(T: type Regex2, s: string): bool {.compileTime.} =
   try:
     discard reCt(s)
     true
   except RegexError:
     false
 
-func reCheckMsg(T: type Regex2, s: string): string {.compileTime.} =
+func errMsg(T: type Regex2, s: string): string {.compileTime.} =
   try:
     discard reCt(s)
     ""
@@ -551,8 +551,8 @@ template `~`*(s: string): Regex2 =
   ## - Cached for later usage.
   const ss = s
   when ss notin tildesVm:
-    when not reCheck(Regex2, ss):
-      {.error: "RegexError: \n" & reCheckMsg(Regex2, ss).}
+    when not check(Regex2, ss):
+      {.error: "RegexError: \n" & errMsg(Regex2, ss).}
   {.cast(gcsafe), cast(noSideEffect).}:
     tildeImpl(Regex2, ss)
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -514,7 +514,7 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-var tildesct {.compileTime.} = initTable[string, Regex2]()
+var tildesct {.compileTime.}: Table[string, Regex2]
 var tildes {.threadvar.}: Table[string, Regex2]
 
 func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -536,6 +536,11 @@ func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =
       tildes[s] = toRegex2 reImpl(s)
       return tildes[s]
 
+func regexDestroyCache* {.gcsafe.} =
+  ## Destroy tilde (``~``) cache.
+  {.cast(noSideEffect).}:
+    tildes = default(Table[string, Regex2])
+
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.
   ## Slice of start > end are empty

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -507,56 +507,53 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
-proc reCheck(s: string): bool {.compileTime.} =
+func reCheck(s: string): bool {.compileTime.} =
   try:
     discard reCt(s)
     true
   except RegexError:
     false
 
-proc reCheckMsg(s: string): string {.compileTime.} =
+func reCheckMsg(s: string): string {.compileTime.} =
   try:
     discard reCt(s)
     ""
-  except RegexError:
-    getCurrentExceptionMsg()
+  except RegexError as err:
+    err.msg
 
 var tildesVm {.compileTime.}: Table[string, Regex2]
 var tildes {.threadvar.}: Table[string, Regex2]
 
-proc tildeImpl(reg: var Regex2, s: string) =
+template tildeImpl(T: type Regex2, s: string): T =
   try:
     when nimvm:
-      reg =
-        if s in tildesVm:
-          tildesVm[s]
-        else:
-          tildesVm[s] = toRegex2 reImpl(s)
-          tildesVm[s]
+      if s in tildesVm:
+        tildesVm[s]
+      else:
+        tildesVm[s] = toRegex2 reImpl(s)
+        tildesVm[s]
     else:
-      reg =
-        if s in tildes:
-          tildes[s]
-        else:
-          tildes[s] = toRegex2 reImpl(s)
-          tildes[s]
+      if s in tildes:
+        tildes[s]
+      else:
+        tildes[s] = toRegex2 reImpl(s)
+        tildes[s]
   except RegexError as err:
     raiseAssert err.msg
   except KeyError as err:
     raiseAssert err.msg
 
-func `~`*(s: static string): Regex2 {.raises: [], gcsafe.} =
+template `~`*(s: string): Regex2 =
   ## Return a compiled regex.
   ## The regex is:
   ## - Validated at compile-time.
   ## - Compiled at runtime.
   ## - Cached for later usage.
-  when not reCheck(s):
-    {.error: "RegexError: \n" & reCheckMsg(s).}
-  var reg: Regex2
+  when s notin tildesVm:
+    when not reCheck(s):
+      {.error: "RegexError: \n" & reCheckMsg(s).}
   {.cast(gcsafe), cast(noSideEffect).}:
-    tildeImpl(reg, s)
-  reg
+    tildeImpl(Regex2, s)
 
 func regexDestroyCache* {.gcsafe.} =
   ## Destroy tilde (``~``) cache.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -527,13 +527,13 @@ var tildes {.threadvar.}: Table[string, Regex2]
 template tildeImpl(T: type Regex2, s: string): T =
   try:
     when nimvm:
-      if s in tildesVm:
+      if contains(tildesVm, s):
         tildesVm[s]
       else:
         tildesVm[s] = toRegex2 reImpl(s)
         tildesVm[s]
     else:
-      if s in tildes:
+      if contains(tildes, s):
         tildes[s]
       else:
         tildes[s] = toRegex2 reImpl(s)
@@ -550,7 +550,7 @@ template `~`*(s: string): Regex2 =
   ## - Compiled at runtime.
   ## - Cached for later usage.
   const ss = s
-  when ss notin tildesVm:
+  when not contains(tildesVm, ss):
     when not check(Regex2, ss):
       {.error: "RegexError: \n" & errMsg(Regex2, ss).}
   {.cast(gcsafe), cast(noSideEffect).}:

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -549,11 +549,12 @@ template `~`*(s: string): Regex2 =
   ## - Validated at compile-time.
   ## - Compiled at runtime.
   ## - Cached for later usage.
-  when s notin tildesVm:
-    when not reCheck(s):
-      {.error: "RegexError: \n" & reCheckMsg(s).}
+  const ss = s
+  when ss notin tildesVm:
+    when not reCheck(ss):
+      {.error: "RegexError: \n" & reCheckMsg(ss).}
   {.cast(gcsafe), cast(noSideEffect).}:
-    tildeImpl(Regex2, s)
+    tildeImpl(Regex2, ss)
 
 func regexDestroyCache* {.gcsafe.} =
   ## Destroy tilde (``~``) cache.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -507,32 +507,65 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
-proc reCheck(s: string): string =
+proc reCheck(s: string): bool {.compileTime.} =
   try:
     discard reCt(s)
-    return ""
-  except RegexError as err:
-    return "[RegexError] " & err.msg
+    true
+  except RegexError:
+    false
 
-func `~`*(s: static string): lent Regex2 =
+proc reCheckMsg(s: string): string {.compileTime.} =
+  try:
+    discard reCt(s)
+    ""
+  except RegexError:
+    getCurrentExceptionMsg()
+
+var tildesVm {.compileTime.}: Table[string, Regex2]
+var tildes {.threadvar.}: Table[string, Regex2]
+
+proc tildeImpl(reg: var Regex2, s: string) =
+  try:
+    when nimvm:
+      reg =
+        if s in tildesVm:
+          tildesVm[s]
+        else:
+          tildesVm[s] = toRegex2 reImpl(s)
+          tildesVm[s]
+    else:
+      reg =
+        if s in tildes:
+          tildes[s]
+        else:
+          tildes[s] = toRegex2 reImpl(s)
+          tildes[s]
+  except RegexError as err:
+    raiseAssert err.msg
+  except KeyError as err:
+    raiseAssert err.msg
+
+func `~`*(s: static string): Regex2 {.raises: [], gcsafe.} =
   ## Return a compiled regex.
   ## The regex is:
   ## - Validated at compile-time.
   ## - Compiled at runtime.
   ## - Cached for later usage.
-  when reCheck(s) != "":
-    {.error: reCheck(s).}
-  {.cast(noSideEffect), cast(gcsafe), cast(raises: []).}:
-    when nimvm:
-      const rvm = toRegex2 reImpl(s)
-      return rvm
-    else:
-      when defined(gcDestructors):
-        var reg {.global.} = toRegex2 reImpl(s)
-        return reg
-      else:
-        const reg = toRegex2 reImpl(s)
-        return reg
+  when not reCheck(s):
+    {.error: "RegexError: \n" & reCheckMsg(s).}
+  var reg: Regex2
+  {.cast(gcsafe), cast(noSideEffect).}:
+    tildeImpl(reg, s)
+  reg
+
+func regexDestroyCache* {.gcsafe.} =
+  ## Destroy tilde (``~``) cache.
+  when nimvm:
+    {.cast(gcsafe), cast(noSideEffect).}:
+      tildesVm = default(Table[string, Regex2])
+  else:
+    {.cast(noSideEffect).}:
+      tildes = default(Table[string, Regex2])
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.
@@ -1250,9 +1283,9 @@ when isMainModule:
   doAssert not compiles(re2"(+)")
 
   doAssert ~r"\w" in "abcd"
-  doAssert ~"ab" in "abcd"
-  doAssert ~"zx" notin "abcd"
-  doAssert not compiles(~"(+)")
+  doAssert ~r"ab" in "abcd"
+  doAssert ~r"zx" notin "abcd"
+  doAssert not compiles(~r"(+)")
 
   # bug: raises invalid utf8 regex in Nim 1.0 + js target
   when not defined(js) or NimMajor >= 2:

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -515,29 +515,27 @@ proc reCheck(s: string) {.compileTime.} =
     raise newException(RegexError, getCurrentExceptionMsg())
 
 var tildesct {.compileTime.} = initTable[string, Regex2]()
-var tildes = initTable[string, Regex2]()
-var tildelock: Lock
-initLock(tildelock)
+var tildes {.threadvar.}: Table[string, Regex2]
 
-func `~`*(s: static string): lent Regex2 {.raises: [RegexError].} =
+func `~`*(s: static string): Regex2 {.raises: [RegexError], gcsafe.} =
   ## Compile a regex at runtime.
   ## The compiled regex is cached for later usage.
-  ## It gets compiled once in a program lifetime.
+  ## It gets compiled once per thread.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+  {.cast(noSideEffect), cast(raises: [RegexError]).}:
     when nimvm:
-      if s in tildesct:
+      {.cast(gcsafe).}:
+        if s in tildesct:
+          return tildesct[s]
+        tildesct[s] = toRegex2 reImpl(s)
         return tildesct[s]
-      tildesct[s] = toRegex2 reImpl(s)
-      return tildesct[s]
     else:
-      withLock tildelock:
-        if s in tildes:
-          return tildes[s]
-        tildes[s] = toRegex2 reImpl(s)
+      if s in tildes:
         return tildes[s]
+      tildes[s] = toRegex2 reImpl(s)
+      return tildes[s]
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -506,6 +506,11 @@ proc reCheck(s: string) {.compileTime.} =
     raise newException(RegexError, getCurrentExceptionMsg())
 
 func `~`*(s: static string): Regex2 =
+  ## Compile a regex at runtime.
+  ## The compiled regex is cached and reused.
+  ## It gets compiled once in a program lifetime.
+  ## The regex is validated at compile-time,
+  ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
   {.cast(noSideEffect), cast(gcsafe).}:
     var reg {.global.} = toRegex2 reImpl(s)

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -507,14 +507,14 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
-func reCheck(s: string): bool {.compileTime.} =
+func reCheck(T: type Regex2, s: string): bool {.compileTime.} =
   try:
     discard reCt(s)
     true
   except RegexError:
     false
 
-func reCheckMsg(s: string): string {.compileTime.} =
+func reCheckMsg(T: type Regex2, s: string): string {.compileTime.} =
   try:
     discard reCt(s)
     ""
@@ -551,8 +551,8 @@ template `~`*(s: string): Regex2 =
   ## - Cached for later usage.
   const ss = s
   when ss notin tildesVm:
-    when not reCheck(ss):
-      {.error: "RegexError: \n" & reCheckMsg(ss).}
+    when not reCheck(Regex2, ss):
+      {.error: "RegexError: \n" & reCheckMsg(Regex2, ss).}
   {.cast(gcsafe), cast(noSideEffect).}:
     tildeImpl(Regex2, ss)
 

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1224,6 +1224,7 @@ when isMainModule:
   doAssert match("A", re2"(?xi)     a")
   doAssert(not match("A", re2"((?xi))     a"))
   doAssert(not match("A", re2"(?xi:(?xi)     )a"))
+  doAssert not compiles(re2"(+)")
 
   doAssert ~"ab" in "abcd"
   doAssert ~"zx" notin "abcd"

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -428,6 +428,7 @@ To compile the regex at runtime pass the regex expression as a ``var/let``.
 
 ]##
 
+import std/locks
 import std/tables
 import std/sequtils
 import std/unicode
@@ -505,16 +506,26 @@ proc reCheck(s: string) {.compileTime.} =
   except RegexError:
     raise newException(RegexError, getCurrentExceptionMsg())
 
-func `~`*(s: static string): Regex2 {.nodestroy.} =
+var tildes = initTable[string, Regex2]()
+var tildelock: Lock
+initLock(tildelock)
+
+func `~`*(s: static string): Regex2 {.raises: [RegexError].} =
   ## Compile a regex at runtime.
   ## The compiled regex is cached and reused.
   ## It gets compiled once in a program lifetime.
   ## The regex is validated at compile-time,
   ## and so it may only raise a `RegexError` at compile-time.
   static: reCheck(s)
-  {.cast(noSideEffect), cast(gcsafe).}:
-    var reg {.global.} = toRegex2 reImpl(s)
-    return reg
+  when nimvm:
+    return toRegex2 reImpl(s)
+  else:
+    {.cast(noSideEffect), cast(gcsafe), cast(raises: [RegexError]).}:
+      withLock tildelock:
+        if s in tildes:
+          return tildes[s]
+        tildes[s] = toRegex2 reImpl(s)
+        return tildes[s]
 
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -499,6 +499,18 @@ when not defined(forceRegexAtRuntime):
     ## Parse and compile a regular expression at compile-time
     toRegex2 reCt(s, flags)
 
+proc reCheck(s: string) {.compileTime.} =
+  try:
+    discard re2(s)
+  except RegexError:
+    raise newException(RegexError, getCurrentExceptionMsg())
+
+func `~`*(s: static[string]): Regex2 =
+  static: reCheck(s)
+  {.cast(noSideEffect), cast(gcsafe).}:
+    var reg {.global.} = re2(s)
+    return reg
+
 func group*(m: RegexMatch2, i: int): Slice[int] {.inline, raises: [].} =
   ## return slice for a given group.
   ## Slice of start > end are empty
@@ -1213,6 +1225,9 @@ when isMainModule:
   doAssert(not match("A", re2"((?xi))     a"))
   doAssert(not match("A", re2"(?xi:(?xi)     )a"))
 
+  doAssert ~"ab" in "abcd"
+  doAssert ~"zx" notin "abcd"
+
   # bug: raises invalid utf8 regex in Nim 1.0 + js target
   when not defined(js) or NimMajor >= 2:
     block:
@@ -1359,6 +1374,8 @@ when isMainModule:
       m.captures == @[0 .. 3, reNonCapture]
     doAssert match("aaab", re2"(\w+)|\w+(?<=^(\w)(\w+))b", m) and
       m.captures == @[0 .. 3, reNonCapture, reNonCapture]
+    doAssert ~"ab" in "abcd"
+    doAssert ~"zx" notin "abcd"
     block:
       var m = false
       var matches = newSeq[string]()

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -1227,6 +1227,7 @@ when isMainModule:
 
   doAssert ~"ab" in "abcd"
   doAssert ~"zx" notin "abcd"
+  doAssert not compiles(~"(+)")
 
   # bug: raises invalid utf8 regex in Nim 1.0 + js target
   when not defined(js) or NimMajor >= 2:

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -20,7 +20,7 @@ template test(desc: string, body: untyped): untyped =
         echo "[CT/RT] " & desc
       body)()
 
-template check(condition: bool) =
+template check(condition: bool): untyped =
   doAssert(condition)
 
 template expect(exception: typedesc, body: untyped): untyped =
@@ -3350,8 +3350,9 @@ test "tvarflags":
 test "tsigil":
   check ~"ab".match "ab"
   check not ~"zx".match "ab"
-  check(~"ab" in "abcd")
-  check(~"zx" notin "abcd")
+  check ~"ab" in "abcd"
+  check ~"zx" notin "abcd"
+  check not compiles(~"(+)")
   try:
     discard ~"(+)"
     doAssert false

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3348,8 +3348,8 @@ test "tvarflags":
     check(not match("a\Lb\L", re2"(?ms)a.b(?-sm:.)"))
 
 test "tsigil":
-  check ~"ab".match "ab"
-  check not ~"zx".match "ab"
+  check match(~"ab", "ab")
+  check not match(~"zx", "ab")
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
@@ -3362,5 +3362,5 @@ test "tsigil":
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =
-    ~"foo".match "foo"
+    match(~"foo", "foo")
   doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3347,14 +3347,14 @@ test "tvarflags":
     check(not match("a\Lb\L", re2(r"a.b(?-sm:.)", {regexDotAll, regexMultiline})))
     check(not match("a\Lb\L", re2"(?ms)a.b(?-sm:.)"))
 
-test "tsigil":
+test "ttilde":
   check "ab".match ~"ab"
   check not "ab".match ~"zx"
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
 
-test "tsigil_gcsafe":
-  func tsigil: bool {.gcsafe.} =
+test "ttilde_gcsafe":
+  func ttilde: bool {.gcsafe.} =
     "foo".match ~"foo"
-  doAssert tsigil()
+  doAssert ttilde()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3353,12 +3353,6 @@ test "tsigil":
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
-  try:
-    discard ~"(+)"
-    doAssert false
-  except RegexError:
-    check getCurrentExceptionMsg() ==
-      "Invalid `+` operator, nothing to repeat"
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3346,3 +3346,20 @@ test "tvarflags":
     check match("a\Lb\L", re2"(?ms)a.b(?s-m:.)")
     check(not match("a\Lb\L", re2(r"a.b(?-sm:.)", {regexDotAll, regexMultiline})))
     check(not match("a\Lb\L", re2"(?ms)a.b(?-sm:.)"))
+
+test "tsigil":
+  check ~"ab".match "ab"
+  check not ~"zx".match "ab"
+  check(~"ab" in "abcd")
+  check(~"zx" notin "abcd")
+  try:
+    discard ~"(+)"
+    doAssert false
+  except RegexError:
+    check getCurrentExceptionMsg() ==
+      "Invalid `+` operator, nothing to repeat"
+
+test "tsigil_gcsafe":
+  func tsigil: bool {.gcsafe.} =
+    ~"foo".match "foo"
+  doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3348,8 +3348,8 @@ test "tvarflags":
     check(not match("a\Lb\L", re2"(?ms)a.b(?-sm:.)"))
 
 test "tsigil":
-  check match(~"ab", "ab")
-  check not match(~"zx", "ab")
+  check "ab".match ~"ab"
+  check not "ab".match ~"zx"
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
@@ -3362,5 +3362,5 @@ test "tsigil":
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =
-    match(~"foo", "foo")
+    "foo".match ~"foo"
   doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3392,12 +3392,6 @@ test "tsigil":
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
-  try:
-    discard ~"(+)"
-    doAssert false
-  except RegexError:
-    check getCurrentExceptionMsg() ==
-      "Invalid `+` operator, nothing to repeat"
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3387,8 +3387,8 @@ test "startsWith openArray[char] test":
     check not startsWith(s.toOpenArray(0, 3), re2"^bcd", m, 1)
 
 test "tsigil":
-  check match(~"ab", "ab")
-  check not match(~"zx", "ab")
+  check "ab".match ~"ab"
+  check not "ab".match ~"zx"
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
@@ -3401,5 +3401,5 @@ test "tsigil":
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =
-    match(~"foo", "foo")
+    "foo".match ~"foo"
   doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3392,8 +3392,10 @@ test "ttilde":
   check ~r"ab" in "abcd"
   check ~r"zx" notin "abcd"
   check not compiles(~r"(+)")
+  regexDestroyCache()
 
 test "ttilde_gcsafe":
   func ttilde: bool {.raises: [], gcsafe.} =
     "foo".match ~r"foo"
   doAssert ttilde()
+  regexDestroyCache()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3387,8 +3387,8 @@ test "startsWith openArray[char] test":
     check not startsWith(s.toOpenArray(0, 3), re2"^bcd", m, 1)
 
 test "tsigil":
-  check ~"ab".match "ab"
-  check not ~"zx".match "ab"
+  check match(~"ab", "ab")
+  check not match(~"zx", "ab")
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
@@ -3401,5 +3401,5 @@ test "tsigil":
 
 test "tsigil_gcsafe":
   func tsigil: bool {.gcsafe.} =
-    ~"foo".match "foo"
+    match(~"foo", "foo")
   doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3386,14 +3386,14 @@ test "startsWith openArray[char] test":
     check m.boundaries == 0 .. 2
     check not startsWith(s.toOpenArray(0, 3), re2"^bcd", m, 1)
 
-test "tsigil":
+test "ttilde":
   check "ab".match ~"ab"
   check not "ab".match ~"zx"
   check ~"ab" in "abcd"
   check ~"zx" notin "abcd"
   check not compiles(~"(+)")
 
-test "tsigil_gcsafe":
-  func tsigil: bool {.gcsafe.} =
+test "ttilde_gcsafe":
+  func ttilde: bool {.gcsafe.} =
     "foo".match ~"foo"
-  doAssert tsigil()
+  doAssert ttilde()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3385,3 +3385,20 @@ test "startsWith openArray[char] test":
     check startsWith(s.toOpenArray(1, 3), re2"^bcd$", m, 0)
     check m.boundaries == 0 .. 2
     check not startsWith(s.toOpenArray(0, 3), re2"^bcd", m, 1)
+
+test "tsigil":
+  check ~"ab".match "ab"
+  check not ~"zx".match "ab"
+  check(~"ab" in "abcd")
+  check(~"zx" notin "abcd")
+  try:
+    discard ~"(+)"
+    doAssert false
+  except RegexError:
+    check getCurrentExceptionMsg() ==
+      "Invalid `+` operator, nothing to repeat"
+
+test "tsigil_gcsafe":
+  func tsigil: bool {.gcsafe.} =
+    ~"foo".match "foo"
+  doAssert tsigil()

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -22,7 +22,7 @@ template test(desc: string, body: untyped): untyped =
         echo "[CT/RT] " & desc
       body)()
 
-template check(condition: bool) =
+template check(condition: bool): untyped =
   doAssert(condition)
 
 template expect(exception: typedesc, body: untyped): untyped =
@@ -3389,8 +3389,9 @@ test "startsWith openArray[char] test":
 test "tsigil":
   check ~"ab".match "ab"
   check not ~"zx".match "ab"
-  check(~"ab" in "abcd")
-  check(~"zx" notin "abcd")
+  check ~"ab" in "abcd"
+  check ~"zx" notin "abcd"
+  check not compiles(~"(+)")
   try:
     discard ~"(+)"
     doAssert false

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3387,13 +3387,13 @@ test "startsWith openArray[char] test":
     check not startsWith(s.toOpenArray(0, 3), re2"^bcd", m, 1)
 
 test "ttilde":
-  check "ab".match ~"ab"
-  check not "ab".match ~"zx"
-  check ~"ab" in "abcd"
-  check ~"zx" notin "abcd"
-  check not compiles(~"(+)")
+  check "ab".match ~r"ab"
+  check not "ab".match ~r"zx"
+  check ~r"ab" in "abcd"
+  check ~r"zx" notin "abcd"
+  check not compiles(~r"(+)")
 
 test "ttilde_gcsafe":
-  func ttilde: bool {.gcsafe.} =
-    "foo".match ~"foo"
+  func ttilde: bool {.raises: [], gcsafe.} =
+    "foo".match ~r"foo"
   doAssert ttilde()

--- a/tests/tests_tilde.nim
+++ b/tests/tests_tilde.nim
@@ -1,0 +1,54 @@
+import std/macros
+import ../src/regex
+
+macro genAsserts(n: static int): untyped =
+  result = newStmtList()
+  for i in 1 .. n:
+    let lhs = newLit("ab" & $i)
+    let rhs = newLit("ab" & $i & $i & $i)
+    result.add(quote do:
+      doAssert(~`lhs` in `rhs`)
+    )
+
+block:
+  proc threadFunc() {.thread.} =
+    doAssert ~r"ab" in "abcd"
+
+  proc test() =
+    var th: Thread[void]
+    createThread(th, threadFunc)
+    joinThread(th)
+
+  test()
+
+block:
+  proc test() =
+    var reg = @[~r"ab1", ~r"ab2", ~r"ab3"]
+    doAssert reg[0] in "ab123"
+    doAssert reg[^1] in "ab321"
+
+  test()
+
+block:
+  proc test() =
+    proc foo(reg: Regex2) =
+      genAsserts(128)
+      doAssert reg in "abcd"
+    foo(~r"ab")
+
+  test()
+
+block:
+  proc threadFunc() {.thread.} =
+    genAsserts(128)
+    doAssert ~r"ab" in "abcd"
+
+  proc test() =
+    var th = newSeq[Thread[void]](16)
+    for i in 0 ..< th.len:
+      createThread(th[i], threadFunc)
+    joinThreads(th)
+
+  test()
+
+echo "ok"

--- a/tests/tests_tilde.nim
+++ b/tests/tests_tilde.nim
@@ -13,6 +13,7 @@ macro genAsserts(n: static int): untyped =
 block:
   proc threadFunc() {.thread.} =
     doAssert ~r"ab" in "abcd"
+    regexDestroyCache()
 
   proc test() =
     var th: Thread[void]
@@ -20,6 +21,7 @@ block:
     joinThread(th)
 
   test()
+  regexDestroyCache()
 
 block:
   proc test() =
@@ -28,6 +30,7 @@ block:
     doAssert reg[^1] in "ab321"
 
   test()
+  regexDestroyCache()
 
 block:
   proc test() =
@@ -37,11 +40,13 @@ block:
     foo(~r"ab")
 
   test()
+  regexDestroyCache()
 
 block:
   proc threadFunc() {.thread.} =
     genAsserts(128)
     doAssert ~r"ab" in "abcd"
+    regexDestroyCache()
 
   proc test() =
     var th = newSeq[Thread[void]](16)
@@ -50,5 +55,6 @@ block:
     joinThreads(th)
 
   test()
+  regexDestroyCache()
 
 echo "ok"


### PR DESCRIPTION
Adds the `tilde` proc which compiles regex at runtime and stores it in a global for caching. Also, it validates the regex at comptime.

```nim
import pkg/regex

doAssert ~r"abc" in "abc"
```

todo: ~~move to some other module as `~(string)` may be used for something else.~~ rename to something else `~(string)` seems far too common.
todo: support `--threads:off`
todo: bench the cache is actually faster than compiling every time