### PR TITLE
import std/assertions

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -432,6 +432,8 @@ import std/tables
 import std/sequtils
 import std/unicode
 from std/strutils import addf
+when NimMajor >= 2:
+  import std/assertions
 
 import ./regex/types
 import ./regex/common

--- a/src/regex/common.nim
+++ b/src/regex/common.nim
@@ -1,6 +1,8 @@
 import std/unicode
 import std/strutils
 import std/algorithm
+when NimMajor >= 2:
+  import std/assertions
 
 type
   RegexError* = object of ValueError

--- a/src/regex/exptransformation.nim
+++ b/src/regex/exptransformation.nim
@@ -2,6 +2,8 @@ import std/unicode
 import std/sets
 import std/tables
 import std/algorithm
+when NimMajor >= 2:
+  import std/assertions
 
 import pkg/unicodedb/casing
 

--- a/src/regex/litopt.nim
+++ b/src/regex/litopt.nim
@@ -48,6 +48,8 @@ https://nitely.github.io/2020/11/30/regex-literals-optimization.html
 import std/algorithm
 import std/sets
 import std/unicode
+when NimMajor >= 2:
+  import std/assertions
 
 import ./types
 import ./nodematch

--- a/src/regex/nfa.nim
+++ b/src/regex/nfa.nim
@@ -1,5 +1,7 @@
 import std/deques
 import std/algorithm
+when NimMajor >= 2:
+  import std/assertions
 
 import ./types
 import ./common

--- a/src/regex/nfafindall.nim
+++ b/src/regex/nfafindall.nim
@@ -3,6 +3,8 @@
 import std/unicode
 import std/tables
 from std/strutils import find
+when NimMajor >= 2:
+  import std/assertions
 
 import ./common
 import ./nodematch

--- a/src/regex/nfafindall2.nim
+++ b/src/regex/nfafindall2.nim
@@ -40,6 +40,8 @@ for the algorithm description
 import std/unicode
 import std/tables
 from std/strutils import find
+when NimMajor >= 2:
+  import std/assertions
 
 import ./common
 import ./nodematch

--- a/src/regex/nfamacro.nim
+++ b/src/regex/nfamacro.nim
@@ -5,6 +5,8 @@ import std/unicode
 import std/tables
 import std/sets
 import std/algorithm
+when NimMajor >= 2:
+  import std/assertions
 
 import pkg/unicodedb/casing
 import pkg/unicodedb/properties

--- a/src/regex/nfamatch.nim
+++ b/src/regex/nfamatch.nim
@@ -2,6 +2,8 @@
 
 import std/unicode
 import std/tables
+when NimMajor >= 2:
+  import std/assertions
 
 import ./common
 import ./nodematch

--- a/src/regex/nfamatch2.nim
+++ b/src/regex/nfamatch2.nim
@@ -2,6 +2,8 @@
 
 import std/unicode
 import std/tables
+when NimMajor >= 2:
+  import std/assertions
 
 import ./common
 import ./nodematch

--- a/src/regex/nfatype.nim
+++ b/src/regex/nfatype.nim
@@ -5,6 +5,8 @@ import std/sets
 import std/algorithm
 import std/math
 import std/bitops
+when NimMajor >= 2:
+  import std/assertions
 
 import ./types
 import ./litopt

--- a/src/regex/nodematch.nim
+++ b/src/regex/nodematch.nim
@@ -1,4 +1,6 @@
 import std/unicode except `==`
+when NimMajor >= 2:
+  import std/assertions
 
 import pkg/unicodedb/casing
 import pkg/unicodedb/properties

--- a/src/regex/oldregex.nim
+++ b/src/regex/oldregex.nim
@@ -4,6 +4,8 @@ import std/tables
 import std/sequtils
 import std/unicode
 from std/strutils import addf
+when NimMajor >= 2:
+  import std/assertions
 
 import ./types
 import ./common

--- a/src/regex/parser.nim
+++ b/src/regex/parser.nim
@@ -3,6 +3,8 @@ import std/strutils
 import std/sets
 import std/parseutils
 import std/sequtils
+when NimMajor >= 2:
+  import std/assertions
 
 import pkg/unicodedb/properties
 

--- a/src/regex/types.nim
+++ b/src/regex/types.nim
@@ -3,6 +3,8 @@
 
 import std/unicode
 from std/sequtils import toSeq
+when NimMajor >= 2:
+  import std/assertions
 
 import pkg/unicodedb/properties
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,4 +1,6 @@
 from std/sequtils import map
+when NimMajor >= 2:
+  import std/assertions
 
 import ../src/regex
 

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -1,6 +1,8 @@
 from std/unicode import runeLen
 from std/sequtils import map
 from std/strutils import contains
+when NimMajor >= 2:
+  import std/assertions
 
 import ../src/regex
 

--- a/tests/tests_misc.nim
+++ b/tests/tests_misc.nim
@@ -55,6 +55,8 @@ DEALINGS IN THE SOFTWARE.
 
 from std/sequtils import map
 from std/strutils import splitLines
+when NimMajor >= 2:
+  import std/assertions
 import ../src/regex
 
 const nonCapture = reNonCapture


### PR DESCRIPTION
I'm implementing new std/nre2 module in Nim's stdlib using https://github.com/nitely/nim-regex to fix https://github.com/nim-lang/Nim/issues/23668.
As `assert` and `doAssert` are moved to `std/assertions` and some Nim test code are compiled with `-d:nimPreviewSlimSystem`, all modules using them need to import `std/assertions`.