### PR TITLE
add `last` parameter to `match` func

### DIFF
--- a/src/regex.nim
+++ b/src/regex.nim
@@ -807,6 +807,17 @@ func startsWith*(
   debugCheckUtf8(s, pattern)
   startsWithImpl2(s, pattern.toRegex, start)
 
+func startsWith*(
+  s: string,
+  pattern: Regex2,
+  m: var RegexMatch2,
+  start = 0,
+  last = int.high
+): bool {.raises: [].} =
+
+  debugCheckUtf8(s, pattern)
+  result = matchImpl(s, pattern.toRegex, m, start, last, {mfAnchored, mfShortestMatch})
+
 func endsWith*(s: string, pattern: Regex2): bool {.raises: [].} =
   ## return whether the string
   ## ends with the pattern or not

--- a/src/regex.nim
+++ b/src/regex.nim
@@ -571,7 +571,8 @@ func match*(
   s: string,
   pattern: Regex2,
   m: var RegexMatch2,
-  start = 0
+  start = 0,
+  last = int.high
 ): bool {.raises: [].} =
   ## return a match if the whole string
   ## matches the regular expression. This
@@ -583,7 +584,7 @@ func match*(
     doAssert not "abcd".match(re2"abc", m)
 
   debugCheckUtf8(s, pattern)
-  result = matchImpl(s, pattern.toRegex, m, start)
+  result = matchImpl(s, pattern.toRegex, m, start, last)
 
 func match*(s: string, pattern: Regex2): bool {.raises: [].} =
   debugCheckUtf8(s, pattern)

--- a/src/regex/nfamatch2.nim
+++ b/src/regex/nfamatch2.nim
@@ -18,7 +18,7 @@ type
     text: string,
     nfa: Nfa,
     look: var Lookaround,
-    start: int,
+    start, last: int,
     flags: MatchFlags
   ): bool {.nimcall, noSideEffect, raises: [].}
   BehindSig = proc (
@@ -58,11 +58,11 @@ func lookAround(
   result = case ntn.kind
   of reLookahead:
     look.ahead(
-      smLa, smLb, capts, captIdx, text, subNfa, look, start, flags2
+      smLa, smLb, capts, captIdx, text, subNfa, look, start, text.high, flags2
     )
   of reNotLookahead:
     not look.ahead(
-      smLa, smLb, capts, captIdx, text, subNfa, look, start, flags2
+      smLa, smLb, capts, captIdx, text, subNfa, look, start, text.high, flags2
     )
   of reLookbehind:
     look.behind(
@@ -179,6 +179,7 @@ func matchImpl(
   nfa: Nfa,
   look: var Lookaround,
   start = 0,
+  last = int.high,
   flags: MatchFlags = {}
 ): bool =
   var
@@ -189,14 +190,15 @@ func matchImpl(
   let
     anchored = mfAnchored in flags
     binFlag = mfBytesInput in flags
-  if start-1 in 0 .. text.len-1:
+    last = min(last, text.high)
+  if start-1 in 0 .. last:
     cPrev = if binFlag:
       text[start-1].int32
     else:
       bwRuneAt(text, start-1).int32
   smA.clear()
   smA.add initPstate(0'i16, captIdx, i .. i-1)
-  while i < text.len:
+  while i <= last:
     if binFlag:
       c = text[iNext].Rune
       inc iNext
@@ -295,6 +297,7 @@ func matchImpl*(
   regex: Regex,
   m: var RegexMatch2,
   start = 0,
+  last = int.high,
   flags: MatchFlags = {}
 ): bool =
   m.clear()
@@ -306,7 +309,7 @@ func matchImpl*(
     captIdx = -1.CaptIdx
     look = initLook()
   result = matchImpl(
-    smA, smB, capts, captIdx, text, regex.nfa, look, start, flags
+    smA, smB, capts, captIdx, text, regex.nfa, look, start, last, flags
   )
   if result:
     m.captures.setLen regex.groupsCount
@@ -334,5 +337,5 @@ func startsWithImpl2*(
     captIdx = -1.CaptIdx
     look = initLook()
   result = matchImpl(
-    smA, smB, capts, captIdx, text, regex.nfa, look, start, flags
+    smA, smB, capts, captIdx, text, regex.nfa, look, start, text.high, flags
   )

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3348,3 +3348,22 @@ test "tvarflags":
     check match("a\Lb\L", re2"(?ms)a.b(?s-m:.)")
     check(not match("a\Lb\L", re2(r"a.b(?-sm:.)", {regexDotAll, regexMultiline})))
     check(not match("a\Lb\L", re2"(?ms)a.b(?-sm:.)"))
+
+test "start-last range":
+  block:
+    var m = RegexMatch2()
+    check match("abcd", re2"bcd", m, 1, 3)
+    check m.boundaries == 1 .. 3
+  block:
+    var m = RegexMatch2()
+    check match("abcd", re2"abc", m, 0, 2)
+    check m.boundaries == 0 .. 2
+    check not match("abcd", re2"abc", m, 0, 1)
+  block:
+    var m = RegexMatch2()
+    check match("abcd", re2"(\w+)", m, 0, 1)
+    check m.boundaries == 0 .. 1
+    check m.group(0) == 0 .. 1
+    check match("abcde", re2"(\w+)", m, 1, 3)
+    check m.boundaries == 1 .. 3
+    check m.group(0) == 1 .. 3

--- a/tests/tests2.nim
+++ b/tests/tests2.nim
@@ -3354,11 +3354,19 @@ test "start-last range":
     var m = RegexMatch2()
     check match("abcd", re2"bcd", m, 1, 3)
     check m.boundaries == 1 .. 3
+    check not match("abcd", re2"bc", m, 1, 3)
+    check startsWith("abcd", re2"bcd", m, 1, 3)
+    check m.boundaries == 1 .. 3
+    check startsWith("abcd", re2"bc", m, 1, 3)
+    check m.boundaries == 1 .. 2
   block:
     var m = RegexMatch2()
     check match("abcd", re2"abc", m, 0, 2)
     check m.boundaries == 0 .. 2
+    check startsWith("abcd", re2"abc", m, 0, 2)
+    check m.boundaries == 0 .. 2
     check not match("abcd", re2"abc", m, 0, 1)
+    check not startsWith("abcd", re2"abc", m, 0, 1)
   block:
     var m = RegexMatch2()
     check match("abcd", re2"(\w+)", m, 0, 1)
@@ -3367,3 +3375,9 @@ test "start-last range":
     check match("abcde", re2"(\w+)", m, 1, 3)
     check m.boundaries == 1 .. 3
     check m.group(0) == 1 .. 3
+  block:
+    var m = RegexMatch2()
+    check not match("xabc", re2"^abc", m, 1)
+    check match("abcx", re2"abc$", m, 0, 2)
+    check not startsWith("xabc", re2"^abc", m, 1)
+    check startsWith("abcx", re2"abc$", m, 0, 2)


### PR DESCRIPTION
I needs `last` parameter to implement a proc similar to [match](https://nim-lang.org/docs/nre.html#match%2Cstring%2CRegex%2Cint) proc.